### PR TITLE
save env vars to file more safely

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -141,7 +141,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            declare -p > jenkins-env
             $ssh_cmd yum -y install rsync
             git rebase --preserve-merges origin/${{ghprbTargetBranch}} \
             && rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
@@ -225,7 +225,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            declare -p > jenkins-env
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -294,7 +294,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            declare -p > jenkins-env
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -335,7 +335,7 @@
             # testing out the cico client
             set +e
             set +x
-            env > jenkins-env
+            declare -p > jenkins-env
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -453,7 +453,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            declare -p > jenkins-env
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -518,7 +518,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            declare -p > jenkins-env
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -622,7 +622,7 @@
             # testing out the cico client
             set +e
             set +x
-            env > jenkins-env
+            declare -p > jenkins-env
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -689,7 +689,7 @@
         - shell: |
             set +e
             set +x
-            env > jenkins-env
+            declare -p > jenkins-env
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -770,7 +770,7 @@
         - shell: |
             set +e
             set +x
-            env > jenkins-env
+            declare -p > jenkins-env
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -835,7 +835,7 @@
         - shell: |
             set +e
             set +x
-            env > jenkins-env
+            declare -p > jenkins-env
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -141,7 +141,8 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             $ssh_cmd yum -y install rsync
             git rebase --preserve-merges origin/${{ghprbTargetBranch}} \
             && rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
@@ -225,7 +226,8 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -294,7 +296,8 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -335,7 +338,8 @@
             # testing out the cico client
             set +e
             set +x
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -453,7 +457,8 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -518,7 +523,8 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -622,7 +628,8 @@
             # testing out the cico client
             set +e
             set +x
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -689,7 +696,8 @@
         - shell: |
             set +e
             set +x
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -770,7 +778,8 @@
         - shell: |
             set +e
             set +x
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -835,7 +844,8 @@
         - shell: |
             set +e
             set +x
-            declare -p > jenkins-env
+            env > jenkins-env
+            declare -p > jenkins-env.sh
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node


### PR DESCRIPTION
Before, we exported environment variables to a file using the command `env > jenkins-env`. This works until you have spaces in the value of the exported variables.

With an env variable like `ghprbPullDescription=Github pull request` the whole thing will break when reading the `jenkins-env` file back in. We have seen [this job](https://ci.centos.org/job/devtools-fabric8-ui/1493/console) for example where we've encountered this error:

```
++ ghprbPullDescription=GitHub
++ pull request
jenkins-env.clean: line 14: pull: command not found
```

This PR fixes the way we save environment variables by using `declare -p` instead of plain `env`. A variable like the above will be stored as `declare -x ghprbPullDescription="GitHub pull 111 request"` and can safely be read in using `source`.

For more information on this type `help declare` in a terminal or look at  [this post](https://unix.stackexchange.com/a/284397/124509).

All consumers of the `jenkins-env` file should be fine if they use `source` to read the values back in.

Don't do something like `sed 's/^/export /g'` on the `jenkins-env` file. If you want to filter out variables, you can so like so:

```sh
cat jenkins-env | grep -E '(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=' > ~/.jenkins-env
source ~/.jenkins-env
```