### PR TITLE
Please increase timeout for fabric8-services/wit coverage tests

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1625,7 +1625,7 @@
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
-            timeout: '90m'
+            timeout: '3h'
         - '{ci_project}-{git_repo}':
             git_repo: fabric8-devdoc
             ci_project: 'devtools'
@@ -1708,7 +1708,7 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             svc_name: core
-            timeout: '1h'
+            timeout: '3h'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: aslakknutsen
             git_repo: almighty-performance

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1593,7 +1593,7 @@
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
-            timeout: '1h'
+            timeout: '90m'
         - '{ci_project}-{git_repo}':
             git_repo: fabric8-devdoc
             ci_project: 'devtools'


### PR DESCRIPTION
This patch increases the timeout to 3 hours for the WIT coverage tests.
This increase is apparently caused by a new dependency on Kubernetes client APIs.