### PR TITLE
Update the job that build single-user Che

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1866,7 +1866,6 @@
             ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
             saas_git: saas-openshiftio
             timeout: '20m'
-
         - '{ci_project}-{git_repo}-build-che-credentials-pr-check':
             git_organization: redhat-developer
             git_repo: rh-che
@@ -1875,11 +1874,11 @@
             ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_run_functional_tests.sh'
             saas_git: saas-openshiftio
             timeout: '20m'
-
         - '{ci_project}-{git_repo}-build-che-credentials-{branch}':
             git_organization: redhat-developer
             git_repo: rh-che
             ci_project: 'devtools'
+            branch: single-user-rh-che
             ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
             #saas_git: saas-openshiftio Do not deploy master branch
             timeout: '20m'


### PR DESCRIPTION
~`master` branch of https://github.com/redhat-developer/rh-che/ has the source code for single user Che. Now that we migrated to multi-user che we don't need to build this branch anymore.~

We have made a copy of current rh-che `master` branch called `single-user-rh-che`. This PR is to change the current single user che build branch to use the new branch. We won't expect any commit in the single-user-rh-che branch but it may be helpful to keep the CI job.

This is the first of 3 steps to merge `multi-tenant-rh-che` branch to `master` in rh-che. Next steps will be to do the actual merge commit in rh-che github repo and then change the CI in cico-jobs to point to master.

cc @ibuziuk @davidfestal @rhopp