### PR TITLE
Che multi-tenant-rh-che branch is now master

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1951,7 +1951,7 @@
             git_organization: redhat-developer
             git_repo: rh-che
             ci_project: 'devtools'
-            branch: multi-tenant-rh-che
+            branch: master
             ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
             saas_git: saas-openshiftio
             timeout: '20m'


### PR DESCRIPTION
Branch `multi-tenant-rh-che` has been merged to master in rh-che repository. This PR is to update the CI to build master branch.