### PR TITLE
fix(test): adjust test run times to avoid collisions and env resets - DO NOT MERGE!

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2200,7 +2200,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '5 4-23/4 * * *'
+            ee_test_start_time: '5 9,12,15,18,21 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: openshift.io
@@ -2209,7 +2209,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '5 5-23/4 * * *'
+            ee_test_start_time: '5 10,13,16,19,22 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: openshift.io
@@ -2218,7 +2218,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '5 6-23/4 * * *'
+            ee_test_start_time: '5 2,5,8,11,14,17,20,23 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: openshift.io
@@ -2228,7 +2228,7 @@
             osio_creds: e9a32e1e-0a38-4a96-896f-a266e1428cf9
             oso_token_creds: e9a32e1e-0a38-4a96-896f-a266e1428cf9
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '5 4-23/4 * * *'
+            ee_test_start_time: '5 9,12,15,18,21 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: openshift.io
@@ -2237,7 +2237,7 @@
             osio_creds: e9a32e1e-0a38-4a96-896f-a266e1428cf9
             oso_token_creds: e9a32e1e-0a38-4a96-896f-a266e1428cf9
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '5 5-23/4 * * *'
+            ee_test_start_time: '5 10,13,16,19,22 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: openshift.io
@@ -2246,7 +2246,7 @@
             osio_creds: e9a32e1e-0a38-4a96-896f-a266e1428cf9
             oso_token_creds: e9a32e1e-0a38-4a96-896f-a266e1428cf9
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '5 6-23/4 * * *'
+            ee_test_start_time: '5 2,5,8,11,14,17,20,23 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2256,7 +2256,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '5 4-23/4 * * *'
+            ee_test_start_time: '5 9,12,15,18,21 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2265,7 +2265,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '5 5-23/4 * * *'
+            ee_test_start_time: '5 10,13,16,19,22 * * *'
             timeout: 60m
             disabled: true
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
@@ -2275,7 +2275,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '5 6-23/4 * * *'
+            ee_test_start_time: '5 2,5,8,11,14,17,20,23 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: openshift.io
@@ -2286,7 +2286,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '0 0 * * *'
+            ee_test_start_time: '5 7 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: openshift.io
@@ -2297,7 +2297,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '30 0 * * *'
+            ee_test_start_time: '5 8 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: openshift.io
@@ -2308,7 +2308,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '0 1 * * *'
+            ee_test_start_time: '5 1 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: openshift.io
@@ -2319,7 +2319,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '30 1 * * *'
+            ee_test_start_time: '5 0 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: openshift.io
@@ -2330,7 +2330,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '0 2 * * *'
+            ee_test_start_time: '5 4 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: openshift.io
@@ -2341,7 +2341,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
-            ee_test_start_time: '30 2 * * *'
+            ee_test_start_time: '5 3 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2352,7 +2352,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '0 0 * * *'
+            ee_test_start_time: '5 7 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2363,7 +2363,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '30 0 * * *'
+            ee_test_start_time: '5 6 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2374,7 +2374,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '0 1 * * *'
+            ee_test_start_time: '5 1 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2385,7 +2385,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '30 1 * * *'
+            ee_test_start_time: '5 0 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2396,7 +2396,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '0 2 * * *'
+            ee_test_start_time: '5 4 * * *'
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
@@ -2407,7 +2407,7 @@
             osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
             oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
-            ee_test_start_time: '30 2 * * *'
+            ee_test_start_time: '5 3 * * *'
             timeout: 60m
         - 'devtools-test-end-to-end-{test_url}-{test_suite}':
             test_url: openshift.io


### PR DESCRIPTION
This pull request requires some explanation.

Ideally, each test should start with a clean environment. However, the current OSIO 'env reset' feature is not 100% reliable and can also require several minutes to run. An enhanced 'delete space' feature, which is not yet available, may resolve this problem.

As a short-term workaround, we will try the following sequence of tests. By resetting the env every 3rd test, and by allowing this reset (1) hour to complete, we hope to be able to run all the tests and not have tests fail due to OSO quotas being exceeded:

00:05 devtools-test-e2e-openshift.io-SpringBootHealth-cluster-one
01:05 devtools-test-e2e-openshift.io-SpringBootHttp-cluster-one
02:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

03:05 devtools-test-e2e-openshift.io-SwarmHealth-cluster-one
04:05 devtools-test-e2e-openshift.io-SwarmHttp-cluster-one
05:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

06:05 devtools-test-e2e-openshift.io-vertxHealth-cluster-one
07:05 devtools-test-e2e-openshift.io-vertxHttp-cluster-one
08:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

09:05 devtools-test-e2e-openshift.io-smoketest-cluster-one
10:05 devtools-test-e2e-openshift.io-analyticstest-cluster-one
11:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

12:05 devtools-test-e2e-openshift.io-smoketest-cluster-one
13:05 devtools-test-e2e-openshift.io-analyticstest-cluster-one
14:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

15:05 devtools-test-e2e-openshift.io-smoketest-cluster-one
16:05 devtools-test-e2e-openshift.io-analyticstest-cluster-one
17:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

18:05 devtools-test-e2e-openshift.io-smoketest-cluster-one
19:05 devtools-test-e2e-openshift.io-analyticstest-cluster-one
20:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

21:05 devtools-test-e2e-openshift.io-smoketest-cluster-one
22:05 devtools-test-e2e-openshift.io-analyticstest-cluster-one
23:05 devtools-test-e2e-openshift.io-chetest-cluster-one   (env reset)

