### PR TITLE
WIP: planner build job on cico

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -270,6 +270,21 @@
     <<: *job_template_defaults
 
 - job-template:
+    name: '{ci_project}-{git_repo}-f8planner-snapshot'
+    image_name: 'MISSING_IMAGE_NAME'
+    wrappers:
+        - registry_devshift_credentials
+        - ansicolor
+    triggers:
+      - github-pull-request:
+          status-context: "ci.centos.org PR build (fabric8-planner)"
+          org-list:
+            - fabric8-planner
+          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry: `docker pull registry.devshift.net/{image_name}:SNAPSHOT-PR-$ghprbPullId`."
+          <<: *github_pull_request_defaults
+    <<: *job_template_defaults
+
+- job-template:
     name: '{ci_project}-{git_repo}-fabric8-analytics-copr-mercator'
     wrappers:
         - copr_mercator_api_token
@@ -2899,7 +2914,7 @@
             saas_git: saas-errortracking
             prj_name: sentry-preview
             timeout: '20m'
-        - '{ci_project}-{git_repo}-snapshot':
+        - '{ci_project}-{git_repo}-f8planner-snapshot':
             git_organization: fabric8-ui
             git_repo: fabric8-planner
             ci_project: 'devtools'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2496,3 +2496,9 @@
             f8a_api_url: "https://recommender.api.openshift.io"
             ci_project: 'devtools'
             timeout: '30m'
+        - '{ci_project}-{git_repo}-snapshot':
+            git_organization: fabric8-ui
+            git_repo: fabric8-planner
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '50m'


### PR DESCRIPTION
Added planner job for cico build


Before merge, I want to know if I can test this patch on planner's forked repository.
If I add a webhook to my fork and set `git_organization: pranavgore09` in the job description , will it run from my specified branch?


I have added shell script that we want to run on build [here](https://github.com/pranavgore09/fabric8-planner/tree/cico-planner) in my branch