### PR TITLE
fx(test): added basic login test to run every 15 min as a health check

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2188,6 +2188,16 @@
             timeout: '30m'
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: openshift.io
+            test_suite: logintest
+            cluster: cluster-one
+            after: devtools-fabric8-test-build-master
+            osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
+            oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
+            kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
+            ee_test_start_time: '*/15 * * * *'
+            timeout: 5m
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
+            test_url: openshift.io
             test_suite: smoketest
             cluster: cluster-one
             after: devtools-fabric8-test-build-master
@@ -2214,6 +2224,16 @@
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
             ee_test_start_time: '5 2-23/4 * * *'
             timeout: 60m
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
+            test_url: openshift.io
+            test_suite: logintest
+            cluster: cluster-two
+            after: devtools-fabric8-test-build-master
+            osio_creds: e9a32e1e-0a38-4a96-896f-a266e1428cf9
+            oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
+            kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
+            ee_test_start_time: '*/15 * * * *'
+            timeout: 5m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: openshift.io
             test_suite: smoketest


### PR DESCRIPTION
This PR enables a simple login test (the runs in < 30 seconds) that logs a user into OSIO, and then logs that user out. 

The goal of this test is to provide us with timely data on whether logins are succeeding and enable us to track this as a pass/fail metric in Zabbix over time. This metric should be at 100% as any failure will indicate that the service is failing for at least this one user.

