### PR TITLE
Remove people that have left

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -34,7 +34,6 @@
         - fche
         - fridex
         - gastaldi
-        - hectorj2f
         - hferentschik
         - ibuziuk
         - inoxx03
@@ -48,10 +47,8 @@
         - kishansagathiya
         - kwk
         - l0rd
-        - lavernw1
         - ldimaggi
         - maxandersen
-        - mharpur
         - michaelkleinhenz
         - mindreeper2420
         - mmclanerh
@@ -60,13 +57,11 @@
         - nimishamukherjee
         - nurali-techie
         - pkajaba
-        - pmuir
         - ppitonak
         - pranavgore09
         - Preeticp
         - rhoads-zach
         - rhopp
-        - Ritsyy
         - riuvshyn
         - sanbornsen
         - sbose78
@@ -78,7 +73,6 @@
         - tradej
         - tsmaeder
         - vikram-raj
-        - VineetReynolds
         - vpavlin
         - xcoulon
 


### PR DESCRIPTION
The people that are removed by this commit have left. 'mharpur' is a special case because his github account does not exist.