### PR TITLE
Run documentation strings check job on CI for the stack-analysis repository

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2584,6 +2584,8 @@
             timeout: '20m'
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: fabric8-analytics-stack-analysis
+        - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
+            git_repo: fabric8-analytics-stack-analysis
         - '{ci_project}-{git_repo}-fabric8-analytics':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-license-analysis


### PR DESCRIPTION
We need to run the job to CI that checks documentation strings in all (Python) source files in the fabric8-analytics-stack-analysis repository.