### PR TITLE
Adding status-context 

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1228,6 +1228,7 @@
         - github
         - githubprb:
             github_hooks: '{github_hooks}'
+            status-context: 'ci.centos.org PR check on {test_url}'
     <<: *che-functional-tests-template
 
 - job:


### PR DESCRIPTION
Adding status-context to be able to see status of both jobs running on PR check. 