### PR TITLE
fix planner api tests trigger time

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1627,7 +1627,7 @@
 - job-template:
     name: 'devtools-test-end-to-end-{test_url}-planner-api-test'
     triggers:
-      - timed: '0 0 * * * *'
+      - timed: '0 4 * * *'
     wrappers:
       - credentials-binding:
         - text:


### PR DESCRIPTION
This PR fixes -
- Trigger time (run tests once a day at 4am ) for devtools-test-end-to-end-openshift.io-planner-api-test job