### PR TITLE
fix(test):  add a simple login test - to verify that users are able to login successfully

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2334,6 +2334,16 @@
             timeout: 60m
         - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
             test_url: prod-preview.openshift.io
+            test_suite: logintest
+            cluster: cluster-one
+            after: devtools-fabric8-test-build-master
+            osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
+            oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
+            kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
+            ee_test_start_time: '*/15 * * * *'
+            timeout: 5m
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{cluster}':
+            test_url: prod-preview.openshift.io
             test_suite: smoketest
             cluster: cluster-one
             after: devtools-fabric8-test-build-master


### PR DESCRIPTION
This test will run for about 30 seconds every 15 minutes and serve as part of a general health check on the system.