### PR TITLE
Enable master branch builds for gemini server

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2873,6 +2873,15 @@
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
             image_name: 'fabric8-analytics/f8a-gemini-server'
+        - '{ci_project}-{git_repo}-f8a-build-master':
+            git_organization: fabric8-analytics
+            git_repo: fabric8-gemini-server
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            saas_git: saas-analytics
+            deployment_units: 'gemini'
+            deployment_configs: 'f8a-gemini-server'
+            timeout: '20m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-vscode-extension


### PR DESCRIPTION
This PR will enable CI builds for [gemini server](https://github.com/fabric8-analytics/fabric8-gemini-server) master branch.