### PR TITLE
Run pylint and pydoc checkers on CI for each PR to the gemini-server repo

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2897,6 +2897,10 @@
             git_repo: fabric8-analytics-recommender
         - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
             git_repo: fabric8-analytics-recommender
+        - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
+            git_repo: fabric8-gemini-server
+        - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
+            git_repo: fabric8-gemini-server
         - '{ci_project}-{git_repo}-build-master':
             git_organization: rhdt
             git_repo: chat


### PR DESCRIPTION
We need to run two jobs for each PR to the gemini-server repository: Pylint and pydoc checkers. The setup is the same as for other fabric8-analytics repositories