### PR TITLE
Run Pydoc checker job on CI for all PRs to fabric8-analytics-worker repo

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2738,6 +2738,8 @@
             timeout: '30m'
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: fabric8-analytics-worker
+        - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
+            git_repo: fabric8-analytics-worker
         - '{ci_project}-{git_repo}-fabric8-analytics':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-server


### PR DESCRIPTION
We'd like to run Pydoc checker job on CI for all PRs made in fabric8-analytics-worker repository.