### PR TITLE
View both jobs run on PR

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1228,9 +1228,10 @@
     name: '{ci_project}-{git_repo}-prcheck-{test_url}'
     triggers:
         - github
-        - githubprb:
+        - github-pull-request:
             github_hooks: '{github_hooks}'
             status-context: 'ci.centos.org PR check on {test_url}'
+            <<: *github_pull_request_defaults
     <<: *che-functional-tests-template
 
 - job:


### PR DESCRIPTION
There are two jobs triggered on PR but only one is shown in github. Trying to make both visible. 