### PR TITLE
[f8a] Update the list of deployment units and configs for workers and Gremlin

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2785,8 +2785,8 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-analytics
-            deployment_units: 'worker-ingestion worker-api worker-ingestion-graph-import worker-api-graph-import'
-            deployment_configs: 'bayesian-worker-ingestion bayesian-worker-api bayesian-worker-ingestion-graph-import bayesian-worker-api-graph-import'
+            deployment_units: 'worker-ingestion worker-api worker-priority worker-ingestion-graph-import worker-api-graph-import worker-priority-graph-import worker-api-dispatcher worker-ingestion-dispatcher worker-priority-dispatcher'
+            deployment_configs: 'bayesian-worker-ingestion bayesian-worker-api bayesian-worker-priority bayesian-worker-ingestion-graph-import bayesian-worker-api-graph-import bayesian-worker-priority-graph-import bayesian-worker-ingestion-dispatcher bayesian-worker-api-dispacher bayesian-worker-priority-dispacher'
             timeout: '30m'
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: fabric8-analytics-worker

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2711,8 +2711,8 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-analytics
-            deployment_units: 'gremlin-http'
-            deployment_configs: 'bayesian-gremlin-http'
+            deployment_units: 'gremlin-http gremlin-http-ingestion'
+            deployment_configs: 'bayesian-gremlin-http bayesian-gremlin-httpingestion'
             timeout: '1h'
         - '{ci_project}-{git_repo}-fabric8-analytics':
             git_organization: fabric8-analytics


### PR DESCRIPTION
Downstream job which runs E2E tests needs to know which units from saas-analytics should be deployed and which deployments to rollback, if the tests failed.

This PR adds units/configs which are not new, but were previously missing.