### PR TITLE
Update after the rename of a repo

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2019,11 +2019,10 @@
             timeout: '10m'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-services
-            git_repo: fabric8-tenant-che-migration
+            git_repo: che-tenant-maintainer
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-openshiftio
-            saas_service_name: che-tenant-maintainer
             timeout: '10m'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-services


### PR DESCRIPTION
Update after the rename of the `fabric8-tenant-che-migration` repo to `che-tenant-maintainer`