### PR TITLE
update credential binding parameter

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1701,7 +1701,7 @@
       - credentials-binding:
         - text:
             credential-id: 1b1d24cc-7bf5-46dc-a112-657de8f1388c
-            EE_TEST_OSIO_TOKEN: Token
+            variable: EE_TEST_OSIO_TOKEN
     scm:
       - git:
             url: https://github.com/{git_organization}/{git_repo}.git


### PR DESCRIPTION
This PR fixes:
  credential binding type text parameter variable( where secret will be stored) for job devtools-test-end-to-end-openshift.io-planner-api-test job