### PR TITLE
Removed launcher-backend PR builds from ci.centos.org

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1636,66 +1636,6 @@
     <<: *job_template_build_defaults
 
 - job-template:
-    name: 'devtools-launcher-backend'
-    wrappers:
-        - registry_devshift_credentials
-        - fabric8_launcher_credentials_wrapper
-    builders:
-        - shell: |
-            # testing out the cico client
-            set +e
-            cp ~/artifacts.key .
-            export CICO_API_KEY=$(cat ~/duffy.key )
-            # get node
-            n=1
-            while true
-            do
-                cico_output=$(cico node get -f value -c ip_address -c comment)
-                if [ $? -eq 0 ]; then
-                    read CICO_hostname CICO_ssid <<< $cico_output
-                    if  [ ! -z "$CICO_hostname" ]; then
-                        # we got hostname from cico
-                        break
-                    fi
-                    echo "'cico node get' succeed, but can't get hostname from output"
-                fi
-                if [ $n -gt 5 ]; then
-                    # give up after 5 tries
-                    echo "giving up on 'cico node get'"
-                    exit 1
-                fi
-                echo "'cico node get' failed, trying again in 60s ($n/5)"
-                n=$[$n+1]
-                sleep 60
-            done
-            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
-            ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
-            $ssh_cmd yum -y install rsync
-            if [ -n "${{ghprbTargetBranch}}" ]; then
-                git rebase --preserve-merges origin/${{ghprbTargetBranch}}
-            else
-                echo "Not a PR build, using master"
-            fi
-            cat $FABRIC8_LAUNCHER_CREDENTIALS >> launcher-env-template.sh            
-            rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
-            && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
-            rtn_code=$?
-            if [ $rtn_code -eq 0 ]; then
-                cico node done $CICO_ssid
-            else
-                if [[ $rtn_code -eq 124 ]]; then
-                   echo "BUILD TIMEOUT";
-                   cico node done $CICO_ssid
-                else
-                    # fail mode gives us 12 hrs to debug the machine
-                    curl "http://admin.ci.centos.org:8080/Node/fail?key=$CICO_API_KEY&ssid=$CICO_ssid"
-                fi
-            fi
-            exit $rtn_code        
-    <<: *job_template_defaults
-
-- job-template:
     name: 'devtools-test-end-to-end-{test_url}-planner-api-test'
     triggers:
       - timed: '0 4 * * *'
@@ -2237,12 +2177,6 @@
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-launchpad
             prj_name: launchpad-preview
-        - 'devtools-launcher-backend':
-            git_organization: fabric8-launcher
-            git_repo: launcher-backend
-            ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_run_tests.sh'
-            timeout: '60m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-launcher
             git_repo: launcher-documentation


### PR DESCRIPTION
The PR builds are broken and the SD team assigned the issue as a low-priority issue, which blocks our work (broken since March 14th), so in order to save work from the SD team, I decided to move the PR builds to Semaphore CI. 

The master builds are still run and deployed in the OSIO clusters