### PR TITLE
removed publishers for job

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1699,7 +1699,7 @@
 - job-template:
     name: 'devtools-test-end-to-end-{test_url}-planner-api-test'
     triggers:
-      - timed: '0 4 * * *'
+      - timed: '0 */4 * * *'
     wrappers:
       - credentials-binding:
         - text:
@@ -1753,9 +1753,6 @@
             cico node done $CICO_ssid
             exit $rtn_code
     <<: *job_template_defaults
-    publishers:
-        - junit:
-            results: ./pytest_junit_logs.xml
 
 - job-template:
     name: '{ci_project}-{git_repo}-promote-to-prod'


### PR DESCRIPTION
This PR :

- changes trigger time for job to every 4 hours
- and removes publisher for job devtools-test-end-to-end-openshift.io-planner-api-test job