### PR TITLE
Improve output of cico-jobs-jjb-test

### DIFF
--- a/cico_pr_test.sh
+++ b/cico_pr_test.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/bash
 
-set -ex
+set -x
 
 NEW_JOBS=$(mktemp -d)
 MASTER_JOBS=$(mktemp -d)
 
+delete_tmp() {
+    rm -rf $NEW_JOBS $MASTER_JOBS
+}
+
 jenkins-jobs test devtools-ci-index.yaml -o $NEW_JOBS
+ret=$?
+
+if [ "$ret" != "0" ]; then
+    delete_tmp
+    exit $ret
+fi
 
 git show origin/master:devtools-ci-index.yaml | jenkins-jobs test -o $MASTER_JOBS
 
 diff -uNr $MASTER_JOBS $NEW_JOBS
-rm -rf $MASTER_JOBS $NEW_JOBS
+
+delete_tmp
+
+exit 0

--- a/cico_pr_test.sh
+++ b/cico_pr_test.sh
@@ -7,7 +7,7 @@ MASTER_JOBS=$(mktemp -d)
 
 jenkins-jobs test devtools-ci-index.yaml -o $NEW_JOBS
 
-git show master:devtools-ci-index.yaml | jenkins-jobs test -o $MASTER_JOBS
+git show origin/master:devtools-ci-index.yaml | jenkins-jobs test -o $MASTER_JOBS
 
 diff -uNr $MASTER_JOBS $NEW_JOBS
 rm -rf $MASTER_JOBS $NEW_JOBS

--- a/cico_pr_test.sh
+++ b/cico_pr_test.sh
@@ -2,4 +2,12 @@
 
 set -ex
 
-jenkins-jobs test devtools-ci-index.yaml
+NEW_JOBS=$(mktemp -d)
+MASTER_JOBS=$(mktemp -d)
+
+jenkins-jobs test devtools-ci-index.yaml -o $NEW_JOBS
+
+git show master:devtools-ci-index.yaml | jenkins-jobs test -o $MASTER_JOBS
+
+diff -uNr $MASTER_JOBS $NEW_JOBS
+rm -rf $MASTER_JOBS $NEW_JOBS


### PR DESCRIPTION
Instead of displaying the bulk output `jenkins-jobs test`, which is 35K lines long, with this change it will display only the differences between the previous version and the new version, with each job in a different file, making it much simpler to understand the impact of a PR.

The most important functionality, making sure that `jenkins-jobs test` is successful is preserved. If the new `devtools-ci-index.yaml` file is invalid the script will exit != 0.