### PR TITLE
Block commits that remove/rename jobs

### DIFF
--- a/cico_pr_test.sh
+++ b/cico_pr_test.sh
@@ -5,11 +5,13 @@ set -x
 NEW_JOBS=$(mktemp -d)
 MASTER_JOBS=$(mktemp -d)
 
+DEVTOOLS_INDEX="devtools-ci-index.yaml"
+
 delete_tmp() {
     rm -rf $NEW_JOBS $MASTER_JOBS
 }
 
-jenkins-jobs test devtools-ci-index.yaml -o $NEW_JOBS
+jenkins-jobs test $DEVTOOLS_INDEX -o $NEW_JOBS
 ret=$?
 
 if [ "$ret" != "0" ]; then
@@ -17,10 +19,17 @@ if [ "$ret" != "0" ]; then
     exit $ret
 fi
 
-git show origin/master:devtools-ci-index.yaml | jenkins-jobs test -o $MASTER_JOBS
-
+git show origin/master:$DEVTOOLS_INDEX | jenkins-jobs test -o $MASTER_JOBS
 diff -uNr $MASTER_JOBS $NEW_JOBS
-
 delete_tmp
+
+# Check if job list is empty
+JOB_LIST=$(scripts/jenkins-jobs-diff.py $DEVTOOLS_INDEX)
+
+if echo "$JOB_LIST" | grep -q 'in_jenkins_not_in_devtools'; then
+    echo "ERROR: Jobs in jenkins not in the devtools index:"
+    echo "$JOB_LIST"
+    exit 1
+fi
 
 exit 0

--- a/scripts/jenkins-jobs-diff.py
+++ b/scripts/jenkins-jobs-diff.py
@@ -25,7 +25,7 @@ from jenkins_jobs.builder import Builder
 
 JENKINS_JOBS_URL = 'https://ci.centos.org/view/Devtools/api/python'
 DEVTOOLS_URL = 'https://raw.githubusercontent.com/openshiftio/openshiftio-cico-jobs/master/devtools-ci-index.yaml'
-
+UNTRACKED_JOBS = set(['devtools-jjb-service'])
 
 def get_devtools_jobs(devtools_fp):
     builder = Builder("None", None, None, None, plugins_list={})
@@ -57,8 +57,8 @@ def main():
     devtools_jobs = get_devtools_jobs(devtools_fp)
     jenkins_jobs = get_jenkins_jobs(JENKINS_JOBS_URL)
 
-    devtools_not_jenkins = set(devtools_jobs) - set(jenkins_jobs)
-    jenkins_not_devtools = set(jenkins_jobs) - set(devtools_jobs)
+    devtools_not_jenkins = set(devtools_jobs) - set(jenkins_jobs) - UNTRACKED_JOBS
+    jenkins_not_devtools = set(jenkins_jobs) - set(devtools_jobs) - UNTRACKED_JOBS
 
     diff = {}
     if devtools_not_jenkins:


### PR DESCRIPTION
If a commit tries to remove or rename a job in the devtools view in
ci.centos.org, and the job already exists the test will fail.

The rationale behind this is that jobs are not automatically removed
from ci.centos.org when removed from the devtools index, therefore this
additional step forces the admin to manually remove the jobs from
jenkins before accepting the commit.