### PR TITLE
fix(test): add POC test for new booster tests - run the suite once a day - [DO NOT MERGE]

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1567,7 +1567,7 @@
            fingerprint: true
 
 - job-template:
-    name: 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}'
+    name: 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}'
     defaults: global
     node: devtools
     after: fabric8io-fabric8-test-build-master
@@ -2491,7 +2491,7 @@
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
             ee_test_start_time: '5 2-23/4 * * *'
             timeout: 60m
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2503,7 +2503,7 @@
             ee_test_start_time: '0 0 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2515,7 +2515,7 @@
             ee_test_start_time: '30 0 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2527,7 +2527,7 @@
             ee_test_start_time: '0 1 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2539,7 +2539,7 @@
             ee_test_start_time: '30 1 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2551,7 +2551,7 @@
             ee_test_start_time: '0 2 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2563,7 +2563,7 @@
             ee_test_start_time: '30 2 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2575,7 +2575,7 @@
             ee_test_start_time: '0 0 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2587,7 +2587,7 @@
             ee_test_start_time: '30 0 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2599,7 +2599,7 @@
             ee_test_start_time: '0 1 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2611,7 +2611,7 @@
             ee_test_start_time: '30 1 * * *'
             timeout: 60m
             disabled: true
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2622,7 +2622,7 @@
             kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
             ee_test_start_time: '0 2 * * *'
             timeout: 60m
-        - 'devtools-test-e2e-{test_url}-{quickstart_name}-{cluster}':
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
             test_url: prod-preview.openshift.io
             test_suite: smoketest
             cluster: cluster-one
@@ -2634,6 +2634,18 @@
             ee_test_start_time: '30 2 * * *'
             timeout: 60m
             disabled: true
+        - 'devtools-test-e2e-{test_url}-{test_suite}-{quickstart_name}-{cluster}':
+            test_url: prod-preview.openshift.io
+            test_suite: boostersuite
+            cluster: cluster-one
+            release_strategy: releaseStageApproveAndPromote
+            quickstart_name: vertxHttp
+            osio_creds: 9d2a233c-4350-49ab-983d-5b8d0de95f44
+            oso_token_creds: 60ae2fd0-5ab0-4a12-bf75-6a81ab1b915f
+            kc_refresh_token_creds: a75af77c-1137-4ea2-9690-968848b0334e
+            ee_test_start_time: '0 3 * * *'
+            timeout: 60m
+            disabled: false
         - 'devtools-test-end-to-end-{test_url}-{test_suite}':
             test_url: openshift.io
             test_suite: runTest


### PR DESCRIPTION
…day for one quickstart to debug the test process

This PR will enable the new booster suite to run once a day for one quickstart. Eventually, we will want to update this to run for all quickstarts daily. We will also update this to run on all clusters - using a unique username for each cluster.