### PR TITLE
Show actual image name instead of MISSING_IMAGE name for fabric8-planner builds

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -331,8 +331,8 @@
       - github-pull-request:
           status-context: "ci.centos.org PR build (fabric8-planner)"
           org-list:
-            - fabric8-planner
-          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry: Run `docker run -e PROXY_PASS_URL=\"https://api.free-stg.openshift.com\" -p 8080:8080 {image_name}`."
+            - fabric8-ui
+          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry. Run `docker run -p 5000:8080 {image_name}:SNAPSHOT-PR-$ghprbPullId` and visit `http://localhost:5000` to access it."
           <<: *github_pull_request_defaults
     <<: *job_template_defaults
 
@@ -3192,6 +3192,7 @@
             git_repo: fabric8-planner
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
+            image_name: fabric8-ui/fabric8-planner
             timeout: '50m'
         - 'devtools-test-end-to-end-{test_url}-planner-api-test':
             test_url: openshift.io

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -332,7 +332,7 @@
           status-context: "ci.centos.org PR build (fabric8-planner)"
           org-list:
             - fabric8-ui
-          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry. Run `docker run -p 5000:8080 registry.devshift.net/{image_name}:SNAPSHOT-PR-$ghprbPullId` and visit `http://localhost:5000` to access it."
+          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry. Run `docker pull registry.devshift.net/{image_name}:SNAPSHOT-PR-$ghprbPullId && docker run -p 5000:8080 registry.devshift.net/{image_name}:SNAPSHOT-PR-$ghprbPullId` and visit `http://localhost:5000` to access it."
           <<: *github_pull_request_defaults
     <<: *job_template_defaults
 

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -332,7 +332,7 @@
           status-context: "ci.centos.org PR build (fabric8-planner)"
           org-list:
             - fabric8-ui
-          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry. Run `docker run -p 5000:8080 {image_name}:SNAPSHOT-PR-$ghprbPullId` and visit `http://localhost:5000` to access it."
+          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry. Run `docker run -p 5000:8080 registry.devshift.net/{image_name}:SNAPSHOT-PR-$ghprbPullId` and visit `http://localhost:5000` to access it."
           <<: *github_pull_request_defaults
     <<: *job_template_defaults
 


### PR DESCRIPTION
For PR builds, the success comment shows `MISSING_IMAGE_NAME`[0] instead of the actual image name. This PR fixes it.

[0] - https://github.com/fabric8-ui/fabric8-planner/pull/2531#issuecomment-379522291