### PR TITLE
Add master build (release) job for fabric8-planner

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2073,6 +2073,12 @@
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-openshiftio
             timeout: '20m'
+        - '{ci_project}-{git_repo}-npm-publish-build-master':
+            git_organization: fabric8-ui
+            git_repo: fabric8-planner
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            timeout: '1h'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: openshiftio
             git_repo: openshift.io


### PR DESCRIPTION
This PR enables fabric8-planner release from CICO