### PR TITLE
fix(ngx-launcher): Added job configuration to run tests on PR

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3256,3 +3256,9 @@
             git_repo: fabric8-analytics-api-gateway
         - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
             git_repo: fabric8-analytics-api-gateway
+        - '{ci_project}-{git_repo}':
+            git_organization: fabric8-launcher
+            git_repo: ngx-launcher
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '30m'


### PR DESCRIPTION
Added job configuration for fabric8-launcher/ngx-launcher repo to run the tests on every PR