### PR TITLE
Add FABRIC8CD_GH_TOKEN env variable to planner (and UI builds)

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -125,6 +125,9 @@
             - text:
                 credential-id: f8f7db1d-87c8-4f64-bae7-584142e44f8e
                 variable: NPM_TOKEN
+            - text:
+                credential-id: ca93a149-7f35-4be4-b1bf-c6cb2ed83c34
+                variable: FABRIC8CD_GH_TOKEN
 
 - wrapper:
     name: che_credentials_wrapper


### PR DESCRIPTION
Added this token in `npm-build-deliver-cred` wrapper. 

Resolves https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1722