### PR TITLE
Add REFRESH_TOKEN to fabric8-planner master job

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -127,6 +127,14 @@
                 variable: NPM_TOKEN
 
 - wrapper:
+    name: fabric8-planner-test-token
+    wrappers:
+      - credentials-binding:
+        - text:
+            credential-id: 270c316a-5343-4b61-9d1f-e506038c08cd
+            variable: REFRESH_TOKEN
+
+- wrapper:
     name: che_credentials_wrapper
     wrappers:
         - credentials-binding:
@@ -1111,6 +1119,7 @@
     node: "{ci_project}"
     wrappers:
             - npm-build-deliver-creds
+            - fabric8-planner-test-token
             - registry_devshift_credentials
     properties:
         - github:


### PR DESCRIPTION
To run tests on planner master build, we need this token.