### PR TITLE
Template for fabric8-wit PR build

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -399,6 +399,17 @@
     <<: *job_template_defaults
 
 - job-template:
+    name: '{ci_project}-{git_repo}-build-test-image'
+    wrappers:
+      - registry_devshift_credentials
+    triggers:
+      - github-pull-request:
+          status-context: "ci.centos.org PR build (fabric8-wit)"
+          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry. Run `docker pull registry.devshift.net/fabric8-services/fabric8-wit:SNAPSHOT-PR-$ghprbPullId` to get it."
+          <<: *github_pull_request_defaults
+    <<: *job_template_defaults
+
+- job-template:
     name: '{ci_project}-{git_repo}-fabric8-analytics-copr-mercator'
     wrappers:
         - copr_mercator_api_token
@@ -2130,7 +2141,7 @@
             git_repo: openshiftio-cico-jobs
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_pr_test.sh'
-        - '{ci_project}-{git_repo}':
+        - '{ci_project}-{git_repo}-build-test-image':
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -399,7 +399,7 @@
     <<: *job_template_defaults
 
 - job-template:
-    name: '{ci_project}-{git_repo}-build-test-image'
+    name: '{ci_project}-fabric8-wit'
     wrappers:
       - registry_devshift_credentials
     triggers:
@@ -2141,7 +2141,7 @@
             git_repo: openshiftio-cico-jobs
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_pr_test.sh'
-        - '{ci_project}-{git_repo}-build-test-image':
+        - '{ci_project}-fabric8-wit':
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'


### PR DESCRIPTION
fabric8-wit image build Job is being migrated to CICO: https://github.com/fabric8-services/fabric8-wit/pull/2020

Once that PR is merged, the message in PR with details of image would be helpful.
