### PR TITLE
WIP: Issue #606: Discard old analytics jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -316,6 +316,10 @@
     wrappers:
         - registry_devshift_credentials
         - ansicolor
+    properties:
+      - *job_template_defaults_github
+      - build-discarder:
+          num-to-keep: 30
     triggers:
       - github-pull-request:
           status-context: "ci.centos.org PR build (fabric8-analytics)"
@@ -400,6 +404,10 @@
     ci_project: 'devtools'
     ci_cmd: '/bin/bash cico_run_pylint.sh'
     timeout: '20m'
+    properties:
+      - *job_template_defaults_github
+      - build-discarder:
+          num-to-keep: 30
     triggers:
       - github-pull-request:
           status-context: "ci.centos.org pylint run (fabric8-analytics)"
@@ -408,13 +416,16 @@
           <<: *github_pull_request_defaults
     <<: *job_template_defaults
 
-
 - job-template:
     name: '{ci_project}-{git_repo}-fabric8-analytics-pydoc'
     git_organization: fabric8-analytics
     ci_project: 'devtools'
     ci_cmd: '/bin/bash cico_run_pydoc.sh'
     timeout: '20m'
+    properties:
+      - *job_template_defaults_github
+      - build-discarder:
+          num-to-keep: 30
     triggers:
       - github-pull-request:
           status-context: "ci.centos.org check-style run (fabric8-analytics)"


### PR DESCRIPTION
This PR will ensure that only the last 30 jobs for the following jobs
are kept in jenkins, and the rest are discarded:

- `devtools-api-machine-stacks-fabric8-analytics`
- `devtools-f8a-3scale-connect-api-fabric8-analytics`
- `devtools-f8a-server-backbone-fabric8-analytics`
- `devtools-f8a-server-backbone-fabric8-analytics-pydoc`
- `devtools-f8a-server-backbone-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-api-gateway-fabric8-analytics`
- `devtools-fabric8-analytics-api-gateway-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-api-gateway-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-auth-fabric8-analytics`
- `devtools-fabric8-analytics-auth-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-auth-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-common-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-common-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-cvedb-s3-dump-docker-fabric8-analytics`
- `devtools-fabric8-analytics-data-model-fabric8-analytics`
- `devtools-fabric8-analytics-data-model-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-data-model-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-firehose-fetcher-fabric8-analytics`
- `devtools-fabric8-analytics-jobs-fabric8-analytics`
- `devtools-fabric8-analytics-jobs-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-jobs-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-license-analysis-fabric8-analytics`
- `devtools-fabric8-analytics-license-analysis-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-license-analysis-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-npm-insights-fabric8-analytics`
- `devtools-fabric8-analytics-npm-insights-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-npm-insights-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-pgbouncer-fabric8-analytics`
- `devtools-fabric8-analytics-recommender-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-recommender-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-scaler-fabric8-analytics`
- `devtools-fabric8-analytics-server-fabric8-analytics`
- `devtools-fabric8-analytics-server-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-server-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-stack-analysis-base-fabric8-analytics`
- `devtools-fabric8-analytics-stack-analysis-fabric8-analytics`
- `devtools-fabric8-analytics-stack-analysis-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-stack-analysis-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-stack-report-ui-fabric8-analytics`
- `devtools-fabric8-analytics-tagger-fabric8-analytics`
- `devtools-fabric8-analytics-tagger-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-tagger-fabric8-analytics-pylint`
- `devtools-fabric8-analytics-worker-base-fabric8-analytics`
- `devtools-fabric8-analytics-worker-fabric8-analytics`
- `devtools-fabric8-analytics-worker-fabric8-analytics-pydoc`
- `devtools-fabric8-analytics-worker-fabric8-analytics-pylint`
- `devtools-fabric8-gemini-server-fabric8-analytics`
- `devtools-fabric8-gemini-server-fabric8-analytics-pydoc`
- `devtools-fabric8-gemini-server-fabric8-analytics-pylint`
- `devtools-gremlin-docker-fabric8-analytics`