### PR TITLE
Issue #606: Add build-discarder

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -6,6 +6,8 @@
     github_user: almighty-bot
     github_hooks: true
     branch: master
+    discarder_days: -1
+    discarder_num: -1
 
 - admin_list_defaults: &admin_list_defaults
     name: 'admin_list_defaults'
@@ -211,9 +213,11 @@
     concurrent: true
     beforeGetNode: ""
     properties:
-        - &job_template_defaults_github
-          github:
+        - github:
             url: https://github.com/{git_organization}/{git_repo}/
+        - build-discarder:
+            days-to-keep: '{discarder_days}'
+            num-to-keep: '{discarder_num}'
     scm:
         - git-scm:
             git_url: https://{github_user}@github.com/{git_organization}/{git_repo}.git


### PR DESCRIPTION
[build-discarder](https://docs.openstack.org/infra/jenkins-job-builder/properties.html#properties.build-discarder)
manages the deletion of old jobs.

This jobs adds discarder_days and discarder_num to the default job
parameters undert the build-discarder property. The value is set to -1,
which means unlimited.

This will allow jobs to specifically override these values, therefore
limiting the number of old builds.