### PR TITLE
Change deployment name for analytics insights service

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2697,15 +2697,15 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
-            image_name: 'fabric8-analytics/f8a-chester'
+            image_name: 'fabric8-analytics/f8a-npm-insights'
         - '{ci_project}-{git_repo}-f8a-build-master':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-npm-insights
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-analytics
-            deployment_units: 'f8a-chester'
-            deployment_configs: 'f8a-chester'
+            deployment_units: 'f8a-npm-insights'
+            deployment_configs: 'f8a-npm-insights'
             timeout: '20m'
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: fabric8-analytics-npm-insights


### PR DESCRIPTION
As per the [discussion on housekeeping](https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1723) and @jfchevrette's point around keeping naming consistency across the repo/image/deployment names changing the DC name and deployment units, have raised PR's for the corresponding change in the template and the saas-analytics repository.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>

[1] https://github.com/fabric8-analytics/fabric8-analytics-npm-insights/pull/17
[2] https://github.com/openshiftio/saas-analytics/pull/319