### PR TITLE
Fix TARGET export for che build scripts

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1093,7 +1093,7 @@
             # RHEL build
 
             if [ -n "{extra_target}" ]; then
-                $ssh_cmd -t "cd payload && TARGET=\"{extra_target}\" {ci_cmd}"
+                $ssh_cmd -t "cd payload && export TARGET=\"{extra_target}\" && {ci_cmd}"
                 rtn_code=$?
 
                 if [ "$rtn_code" != "0" ]; then


### PR DESCRIPTION
Since the che build scripts have multiple commands concatenated by '&&',
the TARGET variable is only available to the first command.