### PR TITLE
add devtools-toolbox container build

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3128,3 +3128,8 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             timeout: '20m'
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: rhdt
+            git_repo: devtools-toolbox
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'


### PR DESCRIPTION
devtools-toolbox container that ops/sre can use to run ad-hoc commands inside of a pod on an openshift cluster