### PR TITLE
Enable extra_target: rhel for f8a-gemini-server

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2911,6 +2911,7 @@
             deployment_units: 'gemini'
             deployment_configs: 'f8a-gemini-server'
             timeout: '20m'
+            extra_target: rhel
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-vscode-extension


### PR DESCRIPTION
For https://github.com/fabric8-analytics/fabric8-gemini-server/pull/49.