### PR TITLE
Replace ambiguous 'devtools' with 'jjb'

### DIFF
--- a/cico_pr_test.sh
+++ b/cico_pr_test.sh
@@ -5,13 +5,13 @@ set -x
 NEW_JOBS=$(mktemp -d)
 MASTER_JOBS=$(mktemp -d)
 
-DEVTOOLS_INDEX="devtools-ci-index.yaml"
+JJB_INDEX="devtools-ci-index.yaml"
 
 delete_tmp() {
     rm -rf $NEW_JOBS $MASTER_JOBS
 }
 
-jenkins-jobs test $DEVTOOLS_INDEX -o $NEW_JOBS
+jenkins-jobs test $JJB_INDEX -o $NEW_JOBS
 ret=$?
 
 if [ "$ret" != "0" ]; then
@@ -19,23 +19,37 @@ if [ "$ret" != "0" ]; then
     exit $ret
 fi
 
-git show origin/master:$DEVTOOLS_INDEX | jenkins-jobs test -o $MASTER_JOBS
+git show origin/master:$JJB_INDEX | jenkins-jobs test -o $MASTER_JOBS
+
+set +x
+
+echo
 echo "-------------------------------------------------------------------------"
+echo diff -uNr '$MASTER_JOBS' '$NEW_JOBS'
+echo diff -uNr $MASTER_JOBS $NEW_JOBS
+echo
 diff -uNr $MASTER_JOBS $NEW_JOBS
 echo "-------------------------------------------------------------------------"
+echo diff -qr '$MASTER_JOBS' '$NEW_JOBS'
+echo diff -qr $MASTER_JOBS $NEW_JOBS
+echo
 diff -qr $MASTER_JOBS $NEW_JOBS
 echo "-------------------------------------------------------------------------"
 
 delete_tmp
 
 # Check if job list is empty
-JOB_LIST=$(scripts/jenkins-jobs-diff.py $DEVTOOLS_INDEX)
+JOB_DIFF=$(scripts/jenkins-jobs-diff.py $JJB_INDEX 2>/dev/null)
 
-if echo "$JOB_LIST" | grep -q 'in_jenkins_not_in_devtools'; then
-    echo "ERROR: Jobs in jenkins not in the devtools index:"
-    echo "$JOB_LIST"
+echo
+echo "JOB_DIFF:"
+echo "$JOB_DIFF"
+echo
+
+if echo "$JOB_DIFF" | grep -q 'in_jenkins_not_in_jjb'; then
     echo
     echo "====================================================================="
+    echo "ERROR: Found jobs defined in jenkins but not in the devtools jjb index."
     echo "Stopping the execution because some Jobs have not been deleted"
     echo "from ci.centos.org. Please ask a Jenkins admin to remove them, and"
     echo "this test will succeed."


### PR DESCRIPTION
'devtools' is a bad choice to refer to the jjb index, as it's also the
scope of the devtools jobs in jenkins and leads to confusion. It has
been replaced with 'jjb' which is more accurate.