### PR TITLE
remove outdated che job from the ci

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2218,6 +2218,14 @@
             saas_service_name: rh-che6
             timeout: '30m'
             extra_target: rhel
+        - '{ci_project}-{git_repo}-build-che-credentials-{branch}':
+            git_organization: redhat-developer
+            git_repo: rh-che
+            ci_project: 'devtools'
+            branch: master
+            ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
+            saas_git: saas-openshiftio
+            timeout: '20m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-ui
             git_repo: ngx-widgets

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2218,22 +2218,6 @@
             saas_service_name: rh-che6
             timeout: '30m'
             extra_target: rhel
-        - '{ci_project}-{git_repo}-build-che-credentials-{branch}':
-            git_organization: redhat-developer
-            git_repo: rh-che
-            ci_project: 'devtools'
-            branch: master
-            ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
-            saas_git: saas-openshiftio
-            timeout: '20m'
-        - '{ci_project}-{git_repo}-build-che-credentials-{branch}':
-            git_organization: redhat-developer
-            git_repo: rh-che
-            ci_project: 'devtools'
-            branch: single-user-rh-che
-            ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
-            #saas_git: saas-openshiftio Do not deploy master branch
-            timeout: '20m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-ui
             git_repo: ngx-widgets


### PR DESCRIPTION
~~CHE5 is deprecated in favor of CHE6, since we are going to terminate CHE5 on stg / prod there is no need to keep CHE5 related CI jobs~~

~~needed for:
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1577
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1239~~


update, we will need `master` job once rhche6 branch will be merged to master. so it is better to keep that job in place and remove `rhche6` after merge.

but job https://ci.centos.org/job/devtools-rh-che-build-che-credentials-single-user-rh-che/ is not needed anymore and should be removed.
cc: @ibuziuk 