### PR TITLE
Report credential changes

### DIFF
--- a/cico_pr_test.sh
+++ b/cico_pr_test.sh
@@ -35,6 +35,13 @@ echo diff -qr $MASTER_JOBS $NEW_JOBS
 echo
 diff -qr $MASTER_JOBS $NEW_JOBS
 echo "-------------------------------------------------------------------------"
+echo "Credential changes:"
+echo
+SED_EXPR='s/^.*>\(.*\)<.*$/\1/'
+grep -rh credentialsId $MASTER_JOBS|sed "$SED_EXPR"|sort -u > $MASTER_JOBS/old_creds.txt
+grep -rh credentialsId $NEW_JOBS|sed "$SED_EXPR"|sort -u > $NEW_JOBS/new_creds.txt
+diff -U0 $MASTER_JOBS/old_creds.txt $NEW_JOBS/new_creds.txt
+echo "-------------------------------------------------------------------------"
 
 delete_tmp
 


### PR DESCRIPTION
Whenever a new credential is introduced, or removed, it will be reported in the CICO job associated to the PR.

An output example would be (only showing the relevant section):

    -------------------------------------------------------------------------
    Credential changes:
    --- /tmp/tmp.UGEE3J6Ta8/old_creds.txt   2018-05-04 17:14:11.760962333
    +0200
    +++ /tmp/tmp.Uj2bvHvIQF/new_creds.txt   2018-05-04 17:14:11.767962369
    +0200
    @@ -24 +23,0 @@
    -ca93a149-7f35-4be4-b1bf-c6cb2ed83c34
    @@ -29 +27,0 @@
    -dea94aec-467e-4363-9578-3a3a2d0009e6
    @@ -33,0 +32 @@
    +067b4308-107a-43cf-aeeb-ddfd98981b43
    -------------------------------------------------------------------------

This would mean that:

- ca93a149-7f35-4be4-b1bf-c6cb2ed83c34 is removed
- dea94aec-467e-4363-9578-3a3a2d0009e6 is also removed
- 067b4308-107a-43cf-aeeb-ddfd98981b43 has been added

Note that this does not influence the exit code of the PR test.