### PR TITLE
Introduce codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Global Owners
+* @kbsingh @jmelis @riuvshin
+
+
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # Global Owners
 * @kbsingh @jmelis @riuvshin
-
-
-


### PR DESCRIPTION
with codeowners feature, it would be much easier to track / support PRs because codeowners automatically will be assigned as reviewers for every PR and reviewer will get GH notification. So no need to go and check if there are new PRs each time.

@kbsingh @jmelis WDYT ?

more about codeowners feature https://help.github.com/articles/about-codeowners/