### PR TITLE
Run tests for the fabric8 analytics version comparator repo

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3123,6 +3123,16 @@
             git_repo: fabric8-analytics-api-gateway
         - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
             git_repo: fabric8-analytics-api-gateway
+        - '{ci_project}-{git_repo}-fabric8-analytics':
+            git_organization: fabric8-analytics
+            git_repo: fabric8-analytics-version-comparator
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '20m'
+        - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
+            git_repo: fabric8-analytics-version-comparator
+        - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
+            git_repo: fabric8-analytics-version-comparator
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-launcher
             git_repo: ngx-launcher


### PR DESCRIPTION
We'd like to run CI jobs for the https://github.com/fabric8-analytics/fabric8-analytics-version-comparator repository. Can anybody review this MR please?