### PR TITLE
Remove job to build rh-che6 branch

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2213,20 +2213,12 @@
             git_organization: redhat-developer
             git_repo: rh-che
             ci_project: 'devtools'
-            branch: rh-che6
+            branch: master
             ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
             saas_git: saas-openshiftio
             saas_service_name: rh-che6
             timeout: '30m'
             extra_target: rhel
-        - '{ci_project}-{git_repo}-build-che-credentials-{branch}':
-            git_organization: redhat-developer
-            git_repo: rh-che
-            ci_project: 'devtools'
-            branch: master
-            ci_cmd: '/bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh'
-            saas_git: saas-openshiftio
-            timeout: '20m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-ui
             git_repo: ngx-widgets


### PR DESCRIPTION
In rh-che repo we have merged `rh-che6` branch in `master`: https://github.com/redhat-developer/rh-che/pull/676.

Along with this PR we should manually delete the job too: https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-rh-che6