### PR TITLE
set discarder to some analytics jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2594,8 +2594,10 @@
             saas_git: saas-analytics
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: fabric8-analytics-common
+            discarder_days: 30
         - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
             git_repo: fabric8-analytics-common
+            discarder_days: 30
         - '{ci_project}-{git_repo}-f8a-build-master':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-pgbouncer
@@ -2744,6 +2746,7 @@
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '30m'
             image_name: 'bayesian/cucos-worker'
+            discarder_days: 30
         - '{ci_project}-{git_repo}-f8a-build-master':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-worker
@@ -2756,6 +2759,7 @@
             extra_target: rhel
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: fabric8-analytics-worker
+            discarder_days: 30
         - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
             git_repo: fabric8-analytics-worker
         - '{ci_project}-{git_repo}-fabric8-analytics':
@@ -2765,6 +2769,7 @@
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '30m'
             image_name: 'bayesian/bayesian-api'
+            discarder_days: 30
         - '{ci_project}-{git_repo}-f8a-build-master':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-server
@@ -2777,8 +2782,10 @@
             extra_target: rhel
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: fabric8-analytics-server
+            discarder_days: 30
         - '{ci_project}-{git_repo}-fabric8-analytics-pydoc':
             git_repo: fabric8-analytics-server
+            discarder_days: 30
         - '{ci_project}-{git_repo}-fabric8-hdd':
             git_organization: fabric8-hdd
             git_repo: supervisor


### PR DESCRIPTION
set discarder days to **30** for following analytics jobs:
- devtools-fabric8-analytics-common-fabric8-analytics-pydoc
- devtools-fabric8-analytics-common-fabric8-analytics-pylint
- devtools-fabric8-analytics-server-fabric8-analytics
- devtools-fabric8-analytics-server-fabric8-analytics-pydoc
- devtools-fabric8-analytics-server-fabric8-analytics-pylint
- devtools-fabric8-analytics-worker-fabric8-analytics
- devtools-fabric8-analytics-worker-fabric8-analytics-pylint

requested in: https://github.com/openshiftio/openshiftio-cico-jobs/issues/606

please note that if some artifacts should be kept for longer period it should be published to http://artifacts.ci.centos.org/devtools/ by using [publisher](https://docs.openstack.org/infra/jenkins-job-builder/publishers.html?highlight=publishers#publishers.archive) for your jobs
```yaml
publishers:
  - archive:
      artifacts: '*.tar.gz'
      allow-empty: 'true'
      fingerprint: true
      default-excludes: false
```
cc: @msrb 