### PR TITLE
set discarder for auth jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2001,11 +2001,13 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
+            discarder_days: 30
         - '{ci_project}-{git_repo}-coverage':
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             timeout: '3h'
+            discarder_days: 30
         - '{ci_project}-{git_repo}':
             git_repo: fabric8-devdoc
             ci_project: 'devtools'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2437,11 +2437,13 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
+            discarder_days: 30
         - '{ci_project}-{git_repo}-coverage':
             git_repo: fabric8-auth
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             timeout: '45m'
+            discarder_days: 30
         - '{ci_project}-{git_repo}-build-master-coverage':
             git_repo: fabric8-auth
             ci_project: 'devtools'


### PR DESCRIPTION
set discarder days to **30** for following analytics jobs:
- devtools-fabric8-auth
- devtools-fabric8-auth-coverage
- devtools-fabric8-wit
- devtools-fabric8-wit-coverage

requested in: https://github.com/openshiftio/openshiftio-cico-jobs/issues/606

please note that if some artifacts should be kept for longer period it should be published to http://artifacts.ci.centos.org/devtools/ by using [publisher](https://docs.openstack.org/infra/jenkins-job-builder/publishers.html?highlight=publishers#publishers.archive) for your jobs
```yaml
publishers:
  - archive:
      artifacts: '*.tar.gz'
      allow-empty: 'true'
      fingerprint: true
      default-excludes: false
```
cc: @aslakknutsen @alexeykazakov 