### PR TITLE
set discarder for some ui jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2017,6 +2017,7 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '50m'
+            discarder_days: 30
         - '{ci_project}-{git_repo}':
             git_organization: openshiftio
             git_repo: openshift.io
@@ -3132,6 +3133,7 @@
             ci_cmd: '/bin/bash cico_run_tests.sh'
             image_name: fabric8-ui/fabric8-planner
             timeout: '50m'
+            discarder_days: 30
         - 'devtools-test-end-to-end-{test_url}-planner-api-test':
             test_url: openshift.io
             git_organization: fabric8io


### PR DESCRIPTION
set discarder days to **30** for following analytics jobs:
- devtools-fabric8-planner-f8planner
- devtools-fabric8-ui

requested in: https://github.com/openshiftio/openshiftio-cico-jobs/issues/606

please note that if some artifacts should be kept for longer period it should be published to http://artifacts.ci.centos.org/devtools/ by using [publisher](https://docs.openstack.org/infra/jenkins-job-builder/publishers.html?highlight=publishers#publishers.archive) for your jobs
```yaml
publishers:
  - archive:
      artifacts: '*.tar.gz'
      allow-empty: 'true'
      fingerprint: true
      default-excludes: false
```
cc: @joshuawilson 