### PR TITLE
Revert "Template for fabric8-wit PR build (#600)"

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -399,17 +399,6 @@
     <<: *job_template_defaults
 
 - job-template:
-    name: '{ci_project}-fabric8-wit'
-    wrappers:
-      - registry_devshift_credentials
-    triggers:
-      - github-pull-request:
-          status-context: "ci.centos.org PR build (fabric8-wit)"
-          success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry. Run `docker pull registry.devshift.net/fabric8-services/fabric8-wit:SNAPSHOT-PR-$ghprbPullId` to get it."
-          <<: *github_pull_request_defaults
-    <<: *job_template_defaults
-
-- job-template:
     name: '{ci_project}-{git_repo}-fabric8-analytics-copr-mercator'
     wrappers:
         - copr_mercator_api_token
@@ -2141,7 +2130,7 @@
             git_repo: openshiftio-cico-jobs
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_pr_test.sh'
-        - '{ci_project}-fabric8-wit':
+        - '{ci_project}-{git_repo}':
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'


### PR DESCRIPTION
This reverts PR:
https://github.com/openshiftio/openshiftio-cico-jobs/pull/600

This reverted because some jobs are stuck, for example:
https://github.com/fabric8-services/fabric8-wit/pull/1959

We can see:

    ci.centos.org PR build Expected — Waiting for status to be reported

And it doesn't seem to progress