### PR TITLE
Increase timeout for devtools-fabric8-planner-f8planner job

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3412,7 +3412,7 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             image_name: fabric8-ui/fabric8-planner
-            timeout: '50m'
+            timeout: '1h'
             discarder_days: 30
         - 'devtools-test-end-to-end-{test_url}-planner-api-test':
             test_url: openshift.io


### PR DESCRIPTION
Few builds are failing for job devtools-fabric8-planner-f8planner job with timeout, increasing the timeout will help to fix the build failures.