### PR TITLE
WIP: Issue #580: Use python's pipes.quote to quote vars

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -8,6 +8,13 @@
     branch: master
     discarder_days: -1
     discarder_num: -1
+    dump_env: |
+        python -c "
+        import os
+        import pipes
+        for k,v in os.environ.items():
+            print '{{}}={{}}'.format(k,pipes.quote(v))
+        " > jenkins-env
 
 - admin_list_defaults: &admin_list_defaults
     name: 'admin_list_defaults'
@@ -301,7 +308,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            {dump_env}
             $ssh_cmd yum -y install rsync
             if [ -n "${{ghprbTargetBranch}}" ]; then
                 git rebase --preserve-merges origin/${{ghprbTargetBranch}}
@@ -580,7 +587,7 @@
 
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
 
-            env > jenkins-env
+            {dump_env}
 
             # CentOS build
 
@@ -670,7 +677,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            {dump_env}
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -826,7 +833,7 @@
             echo 'Using Host' $CICO_hostname
             set -x
 
-            env > jenkins-env
+            {dump_env}
             cat $creds_config_file >> jenkins-env
 
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
@@ -912,7 +919,9 @@
             done
             echo 'Using Host' $CICO_hostname
 
-            env > integration-tests/jenkins-env
+            {dump_env}
+            mv jenkins-env integration-tests/jenkins-env
+
             gc() {{
                 rtn_code=$?
                 cico node done $CICO_ssid || :
@@ -975,7 +984,9 @@
             # We have to point other endpoints to production too
             export F8A_API_URL={f8a_api_url}
 
-            env > integration-tests/jenkins-env
+            {dump_env}
+            mv jenkins-env integration-tests/jenkins-env
+
             gc() {{
                 rtn_code=$?
                 cico node done $CICO_ssid || :
@@ -1042,7 +1053,8 @@
                 exit 1
             fi
 
-            env > integration-tests/jenkins-env
+            {dump_env}
+            mv jenkins-env integration-tests/jenkins-env
 
             export GIT_COMMIT=$UPSTREAM_GIT_COMMIT
 
@@ -1173,7 +1185,7 @@
             if [ -z "$DEVSHIFT_TAG_LEN" ]; then
                 export DEVSHIFT_TAG_LEN=7
             fi
-            env > jenkins-env
+            {dump_env}
             cat $creds_config_file >> jenkins-env
 
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
@@ -1314,7 +1326,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            {dump_env}
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -1362,7 +1374,7 @@
             # testing out the cico client
             set +e
             set +x
-            env > jenkins-env
+            {dump_env}
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -1564,7 +1576,7 @@
         - shell: |
             set +e
             set +x
-            env > jenkins-env
+            {dump_env}
             cat $creds_config_file >> jenkins-env
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -1647,7 +1659,7 @@
             set +e
             set +x
             export EE_TEST_GITHUB_USERNAME="{gh_username}"
-            env > jenkins-env
+            {dump_env}
             cat $creds_config_file >> jenkins-env
             cp ~/artifacts.key .
             export CICO_API_KEY=$(cat ~/duffy.key )
@@ -1726,7 +1738,7 @@
             export TEST_SUITE="{test_suite}"
             export FEATURE_LEVEL="{feature_level}"
             export ZABBIX_ENABLED="{zabbix_enabled}"
-            env > jenkins-env
+            {dump_env}
             cat $creds_config_file >> jenkins-env
             cp ~/artifacts.key .
             export CICO_API_KEY=$(cat ~/duffy.key )
@@ -1827,7 +1839,7 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
+            {dump_env}
             $ssh_cmd yum -y install rsync
             if [ -n "${{ghprbTargetBranch}}" ]; then
                 git rebase --preserve-merges origin/${{ghprbTargetBranch}}
@@ -1896,7 +1908,7 @@
             done
             echo 'Using Host' $CICO_hostname
 
-            env > jenkins-env
+            {dump_env}
             set -e
 
             # Run E2E tests
@@ -1966,7 +1978,7 @@
             # testing out the cico client
             set +e
             set +x
-            env > jenkins-env
+            {dump_env}
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
             n=1


### PR DESCRIPTION
There are many statements build scripts that dump the environment like
this: `env > jenkins-env`. All of these have been replace by a python
snippet that iterates through all the environment variables and dumps
them safely using
[pipes.quote](https://docs.python.org/2/library/pipes.html#pipes.quote)

The problem that this does not solve is multiline env vars. Many OSIO
scripts will do a `grep <field>` first, dump to a new file, and then
source that file. This is inconvenient as it will discard all but the
first line of the multiline env vars.