### PR TITLE
Issue #580: script to manage the environment vars

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -304,7 +304,11 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
+
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f jenkins-env.json
             env > jenkins-env
+
             $ssh_cmd yum -y install rsync
             if [ -n "${{ghprbTargetBranch}}" ]; then
                 git rebase --preserve-merges origin/${{ghprbTargetBranch}}
@@ -583,6 +587,8 @@
 
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
 
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f jenkins-env.json
             env > jenkins-env
 
             # CentOS build
@@ -673,7 +679,11 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
+
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f jenkins-env.json
             env > jenkins-env
+
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -827,10 +837,20 @@
                 sleep 60
             done
             echo 'Using Host' $CICO_hostname
-            set -x
 
-            env > jenkins-env
-            cat $creds_config_file >> jenkins-env
+            (
+                # run in subshell not to affect current environment
+                set +x
+
+                # load creds_config_file
+                eval "$(sed '/^\s*$/d;s/^/export /' $creds_config_file)"
+
+                cp ~/cico-tools/env-toolkit .
+                ./env-toolkit dump -f jenkins-env.json
+                env > jenkins-env
+            )
+
+            set -x
 
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
@@ -915,7 +935,10 @@
             done
             echo 'Using Host' $CICO_hostname
 
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f integration-tests/jenkins-env.json
             env > integration-tests/jenkins-env
+
             gc() {{
                 rtn_code=$?
                 cico node done $CICO_ssid || :
@@ -978,7 +1001,10 @@
             # We have to point other endpoints to production too
             export F8A_API_URL={f8a_api_url}
 
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f integration-tests/jenkins-env.json
             env > integration-tests/jenkins-env
+
             gc() {{
                 rtn_code=$?
                 cico node done $CICO_ssid || :
@@ -1045,6 +1071,8 @@
                 exit 1
             fi
 
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f integration-tests/jenkins-env.json
             env > integration-tests/jenkins-env
 
             export GIT_COMMIT=$UPSTREAM_GIT_COMMIT
@@ -1176,8 +1204,18 @@
             if [ -z "$DEVSHIFT_TAG_LEN" ]; then
                 export DEVSHIFT_TAG_LEN=7
             fi
-            env > jenkins-env
-            cat $creds_config_file >> jenkins-env
+
+            (
+                # run in subshell not to affect current environment
+                set +x
+
+                # load creds_config_file
+                eval "$(sed '/^\s*$/d;s/^/export /' $creds_config_file)"
+
+                cp ~/cico-tools/env-toolkit .
+                ./env-toolkit dump -f jenkins-env.json
+                env > jenkins-env
+            )
 
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
@@ -1317,7 +1355,11 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
+
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f jenkins-env.json
             env > jenkins-env
+
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
@@ -1365,8 +1407,19 @@
             # testing out the cico client
             set +e
             set +x
-            env > jenkins-env
-            cat $creds_config_file >> jenkins-env
+
+            (
+                # run in subshell not to affect current environment
+                set +x
+
+                # load creds_config_file
+                eval "$(sed '/^\s*$/d;s/^/export /' $creds_config_file)"
+
+                cp ~/cico-tools/env-toolkit .
+                ./env-toolkit dump -f jenkins-env.json
+                env > jenkins-env
+            )
+
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
             n=1
@@ -1567,8 +1620,19 @@
         - shell: |
             set +e
             set +x
-            env > jenkins-env
-            cat $creds_config_file >> jenkins-env
+
+            (
+                # run in subshell not to affect current environment
+                set +x
+
+                # load creds_config_file
+                eval "$(sed '/^\s*$/d;s/^/export /' $creds_config_file)"
+
+                cp ~/cico-tools/env-toolkit .
+                ./env-toolkit dump -f jenkins-env.json
+                env > jenkins-env
+            )
+
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
             n=1
@@ -1650,8 +1714,19 @@
             set +e
             set +x
             export EE_TEST_GITHUB_USERNAME="{gh_username}"
-            env > jenkins-env
-            cat $creds_config_file >> jenkins-env
+
+            (
+                # run in subshell not to affect current environment
+                set +x
+
+                # load creds_config_file
+                eval "$(sed '/^\s*$/d;s/^/export /' $creds_config_file)"
+
+                cp ~/cico-tools/env-toolkit .
+                ./env-toolkit dump -f jenkins-env.json
+                env > jenkins-env
+            )
+
             cp ~/artifacts.key .
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -1729,8 +1804,19 @@
             export TEST_SUITE="{test_suite}"
             export FEATURE_LEVEL="{feature_level}"
             export ZABBIX_ENABLED="{zabbix_enabled}"
-            env > jenkins-env
-            cat $creds_config_file >> jenkins-env
+
+            (
+                # run in subshell not to affect current environment
+                set +x
+
+                # load creds_config_file
+                eval "$(sed '/^\s*$/d;s/^/export /' $creds_config_file)"
+
+                cp ~/cico-tools/env-toolkit .
+                ./env-toolkit dump -f jenkins-env.json
+                env > jenkins-env
+            )
+
             cp ~/artifacts.key .
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
@@ -1830,7 +1916,11 @@
             done
             sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
             ssh_cmd="ssh $sshopts $CICO_hostname"
+
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f jenkins-env.json
             env > jenkins-env
+
             $ssh_cmd yum -y install rsync
             if [ -n "${{ghprbTargetBranch}}" ]; then
                 git rebase --preserve-merges origin/${{ghprbTargetBranch}}
@@ -1899,7 +1989,10 @@
             done
             echo 'Using Host' $CICO_hostname
 
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f jenkins-env.json
             env > jenkins-env
+
             set -e
 
             # Run E2E tests
@@ -1969,7 +2062,11 @@
             # testing out the cico client
             set +e
             set +x
+
+            cp ~/cico-tools/env-toolkit .
+            ./env-toolkit dump -f jenkins-env.json
             env > jenkins-env
+
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
             n=1


### PR DESCRIPTION
Example usage:

```shell
$ env | grep TEST
$ export TEST1="hello
> new line
> single quote: '
> double quote: \"
> and bye"
$ export TEST2="one;two"
$ ./env-toolkit.py dump -f myenv
$ jq . myenv |grep TEST
  "TEST1": "hello\nnew line\nsingle quote: '\ndouble quote: \"\nand bye",
  "TEST2": "one;two",
$ unset TEST1 TEST2
$ env | grep TEST
$ ./env-toolkit.py load -f myenv ^TEST
export TEST1='hello
new line
single quote: '"'"'
double quote: "
and bye'
export TEST2='one;two'
$ eval "$(./env-toolkit.py load -f myenv ^TEST)"
$ echo "$TEST1"
hello
new line
single quote: '
double quote: "
and bye
$ echo "$TEST2"
one;two
```