### PR TITLE
CI job for Jenkins plugin

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3273,3 +3273,9 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             timeout: '20m'
+        - '{ci_project}-{git_repo}-fabric8-analytics':
+            git_organization: fabric8-analytics
+            git_repo: fabric8-analytics-jenkins-plugin
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '20m'


### PR DESCRIPTION
We'd like to run CI job for each PR made in the `https://github.com/fabric8-analytics/fabric8-analytics-jenkins-plugin`. Can anybody review this change please?