### PR TITLE
ansicolor wrapper added to e2e tests template

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1790,6 +1790,7 @@
     triggers:
         - timed: '{ee_test_start_time}'
     wrappers:
+        - ansicolor
         - credentials-binding:
             - username-password-separated:
                 credential-id: "{osio_creds}"


### PR DESCRIPTION
resolves https://github.com/fabric8io/fabric8-test/issues/511

Jenkins log shows artefacts like in the following snippet which is caused by color font. The change in this PR is taken from Planner job where it works fine.
```
[31m    Failed: Wait timed out after 1800005ms[0m
```