### PR TITLE
Fix tag len to 7 for analytics builds

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -848,6 +848,8 @@
             done
             echo 'Using Host' $CICO_hostname
 
+            export DEVSHIFT_TAG_LEN=7
+
             (
                 # run in subshell not to affect current environment
                 set +x


### PR DESCRIPTION
All analytics services currently use a hash_length of 7 so I believe it's
reasonable to hardcode this.

    $ grep hash_length bay-services/*
    bay-services/api-backbone.yaml:  hash_length: 7
    bay-services/api-gateway.yaml:  hash_length: 7
    bay-services/api-machine-stacks.yaml:  hash_length: 7
    bay-services/api.yaml:  hash_length: 7
    bay-services/data-importer.yaml:  hash_length: 7
    bay-services/f8a-3scale-connect-api.yaml:  hash_length: 7
    bay-services/f8a-hpf-insights.yaml:  hash_length: 7
    bay-services/f8a-npm-insights.yaml:  hash_length: 7
    bay-services/firehose-fetcher.yaml:  hash_length: 7
    bay-services/gemini.yaml:  hash_length: 7
    bay-services/gremlin.yaml:  hash_length: 7
    bay-services/jobs.yaml:  hash_length: 7
    bay-services/kronos.yaml:  hash_length: 7
    bay-services/license-analysis.yaml:  hash_length: 7
    bay-services/pgbouncer.yaml:  hash_length: 7
    bay-services/stack-report-ui.yaml:  hash_length: 7
    bay-services/worker-scaler.yaml:  hash_length: 7
    bay-services/worker.yaml:  hash_length: 7