### PR TITLE
Changed route of rh-che PR check deployment

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1520,7 +1520,7 @@
         - github-pull-request:
             github_hooks: '{github_hooks}'
             status-context: 'ci.centos.org PR check on {test_url}'
-            success-comment: "$ghprbPullAuthorLoginMention The che server [build $BUILD_NUMBER] has been successfully deployed: https://rhche-che6-automated.dev.rdu2c.fabric8.io/"
+            success-comment: "$ghprbPullAuthorLoginMention The che server [build $BUILD_NUMBER] has been successfully deployed: http://rhche-che6-automated.dev.rdu2c.fabric8.io/"
             failure-comment: "$ghprbPullAuthorLoginMention The che server [build $BUILD_NUMBER] failed. artifacts: http://artifacts.ci.centos.org/devtools/che-functional-tests/{ci_project}-{git_repo}-rh-che-prcheck-{test_url}/$BUILD_NUMBER/"
             error-comment: "$ghprbPullAuthorLoginMention The che server [build $BUILD_NUMBER] failed. artifacts: http://artifacts.ci.centos.org/devtools/che-functional-tests/{ci_project}-{git_repo}-rh-che-prcheck-{test_url}/$BUILD_NUMBER/"
             <<: *github_pull_request_defaults


### PR DESCRIPTION
Relevant PR on rh-che repository: https://github.com/redhat-developer/rh-che/pull/769