### PR TITLE
Fix branch for pulling che-functional-tests

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1566,6 +1566,11 @@
                 results:
                     - success
                     - failure
+    scm:
+        - git:
+            url: https://{github_user}@github.com/{git_organization}/{git_repo}.git
+            branches:
+                - origin/master
     beforeGetNode: |
         #Wait for correct rh-che version to be deployed & running on prod-preview
         isPodRunning () (


### PR DESCRIPTION
This job used ${ghprbActualCommit} as branch, which is not desired and the build was failing. This should fix that (we want to use origin/master)