### PR TITLE
Rhche test after merge - changed app from "che" to "rhche"

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1588,7 +1588,7 @@
         #Wait for correct rh-che version to be deployed & running on prod-preview
         isPodRunning () (
             echo "Getting status of pod with image tag $IMAGE_TAG"
-            STATUS=`oc get pod -l app=che -o json -n dsaas-preview | jq -r ".items[] | select (.spec.containers[0].image | contains(\"IMAGE_TAG\")).status.phase"`
+            STATUS=`oc get pod -l app=rhche -o json -n dsaas-preview | jq -r ".items[] | select (.spec.containers[0].image | contains(\"IMAGE_TAG\")).status.phase"`
             echo "Status is $STATUS"
             if [ $STATUS = "Running" ]; then
                 return 0


### PR DESCRIPTION
https://ci.centos.org/job/devtools-che-functional-tests-after-rh-che-build-prod-preview.openshift.io/

This job was failing on being unable to get status of rhche pod. That was because label changed from "che" to "rhche".