### PR TITLE
Execute end to end (e2e) tests on fabric8-services/fabric8-wit repo

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -371,6 +371,14 @@
     <<: *job_template_defaults
 
 - job-template:
+    name: '{ci_project}-{git_repo}-e2e'
+    triggers:
+      - github-pull-request:
+          status-context: "ci.centos.org PR build (e2e)"
+          <<: *github_pull_request_defaults
+    <<: *job_template_defaults
+
+- job-template:
     name: '{ci_project}-{git_repo}-wit-go-benchmarks'
     triggers:
       - timed: '59 23 * * 6'
@@ -2421,6 +2429,12 @@
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
+            timeout: '3h'
+            discarder_days: 30
+        - '{ci_project}-{git_repo}-e2e':
+            git_repo: fabric8-wit
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_e2e_tests.sh'
             timeout: '3h'
             discarder_days: 30
         - '{ci_project}-{git_repo}':


### PR DESCRIPTION
Since https://github.com/fabric8-services/fabric8-wit/pull/2235 we now have a stub end to end (e2e) test file in place inside of the fabric8-wit: https://github.com/fabric8-services/fabric8-wit/blob/master/cico_run_e2e_tests.sh. That file does nothing for now but fail. In https://github.com/fabric8-services/fabric8-wit/pull/2235 @rgarg1 is implementing the real end to end tests. This change acts as a preparation for that task.