### PR TITLE
Add dependabot to whitelist

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -29,6 +29,7 @@
         - chrislessard
         - christianvogt
         - corinnekrych
+        - dependabot
         - dgutride
         - DhritiShikhar
         - dipak-pawar


### PR DESCRIPTION
This is a bot from dependabot.com that updates dependency versions.