### PR TITLE
Use `oc rollout` instead of deprecated `oc deploy`

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -547,7 +547,7 @@
         fi
     saasherder_deploy: |
         if [ "$SVC_NAME" != "none" ]; then
-            oc deploy $SVC_NAME --latest -n $PRJ_NAME
+            oc rollout latest $SVC_NAME -n $PRJ_NAME
             rtn_code=$?
         fi
         if [ "$SAAS_GIT" != "none" ]; then
@@ -717,7 +717,7 @@
             if [ $rtn_code -eq 0 ]; then
               cico node done $CICO_ssid
               if [ "{svc_name}" != "none" ]; then
-                oc deploy {svc_name} --latest
+                oc rollout latest {svc_name}
               fi
             else
               # fail mode gives us 12 hrs to debug the machine


### PR DESCRIPTION
Change usage of `oc deploy --latest` to `oc rollout latest`, since `oc deploy` has now been deprecated, as seen in this job's log.

https://ci.centos.org/job/devtools-ngx-base-npm-publish-build-master/19/console

```
+ oc deploy fabric8-ui-ngx-base --latest -n dsaas-preview
Command "deploy" is deprecated, Use the `rollout latest` and `rollout cancel` commands instead.
Flag --latest has been deprecated, use 'oc rollout latest' instead
```