### PR TITLE
Move s2i-config and jenkins-openshift-base to .cico

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4051,25 +4051,25 @@
             git_organization: fabric8-jenkins
             git_repo: jenkins-openshift-base
             ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_deploy.sh'
+            ci_cmd: '/bin/bash .cico/deploy.sh'
             timeout: '20m'
         - '{ci_project}-{git_repo}-fabric8-push-prcheck':
             git_organization: fabric8-jenkins
             git_repo: jenkins-openshift-base
             ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_build.sh'
+            ci_cmd: '/bin/bash .cico/build.sh'
             timeout: '20m'
         - '{ci_project}-{git_repo}-fabric8-push-build-master':
             git_organization: fabric8io
             git_repo: openshift-jenkins-s2i-config
             ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_deploy.sh'
+            ci_cmd: '/bin/bash .cico/deploy.sh'
             timeout: '20m'
         - '{ci_project}-{git_repo}-fabric8-push-prcheck':
             git_organization: fabric8io
             git_repo: openshift-jenkins-s2i-config
             ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_build.sh'
+            ci_cmd: '/bin/bash .cico/build.sh'
             timeout: '20m'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-analytics


### PR DESCRIPTION
Move scripts to .cico directory for jenkins-openshift-base and
openshift-jenkins-s2i-config

Related PR for the move:

https://github.com/fabric8io/openshift-jenkins-s2i-config/pull/207
https://github.com/fabric8-jenkins/jenkins-openshift-base/pull/45