### PR TITLE
Add job for testing rollout

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1663,15 +1663,15 @@
             <<: *github_pull_request_defaults
     <<: *rh-che-automation-template
 
-- test-for-rollout-token: &test-for-rollout-token
-    name: "test-for-rollout-token"
+- rollout-test-token: &rollout-test-token
+    name: "rollout-test-token"
     secret-path: 'devtools-osio-ci/qe-osio-token-for-rollout-test'
     secret-values:
       - env-var: 'CHE_TESTUSER_OFFLINE__TOKEN'
         vault-key: 'token'    
         
-- test-for-rollout-creds: &test-for-rollout-creds
-    name: "test-for-rollout-creds"
+- rollout-test-creds: &rollout-test-creds
+    name: "rollout-test-creds"
     secret-path: 'devtools-osio-ci/qe-osio-creds-for-rollout-test'
     secret-values:
       - env-var: 'CHE_TESTUSER_NAME'
@@ -1684,11 +1684,11 @@
     triggers:
         - timed: 'H 3 * * *'
     wrappers:
-        - vault-secrets:
+      - vault-secrets:
           <<: *vault_defaults
           secrets:
-            - *test-for-rollout-token
-            - *test-for-rollout-creds
+            - *rollout-test-token
+            - *rollout-test-creds
     <<: *rh-che-automation-template
 
 

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1680,7 +1680,7 @@
         vault-key: 'password'
     
 - job-template:
-    name: '{ci_project}-{git_repo}-rh-che-rollout-test-{test_url}'
+    name: '{ci_project}-{git_repo}-rollout-test-{test_url}'
     concurrent: false
     triggers:
         - timed: 'H 3 * * *'
@@ -2776,7 +2776,7 @@
             ci_cmd: 'TARGET="rhel" PR_CHECK_BUILD="true" /bin/bash ./.ci/cico_rhche_prcheck.sh'
             test_url: 'dev.rdu2c.fabric8.io'
             timeout: '60m'
-        - '{ci_project}-{git_repo}-rh-che-rollout-test-{test_url}':
+        - '{ci_project}-{git_repo}-rollout-test-{test_url}':
             git_organization: redhat-developer
             git_repo: rh-che
             ci_project: 'devtools'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1681,6 +1681,7 @@
     
 - job-template:
     name: '{ci_project}-{git_repo}-rh-che-rollout-test-{test_url}'
+    concurrent: false
     triggers:
         - timed: 'H 3 * * *'
     wrappers:
@@ -1689,7 +1690,8 @@
           secrets:
             - *rollout-test-token
             - *rollout-test-creds
-    <<: *rh-che-automation-template
+            - *rh-che-automation-credentials-devrdu2c-fabric8-io
+    <<: *job_template_defaults
 
 
 - che-functional-tests-template: &che-functional-tests-template

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1663,6 +1663,35 @@
             <<: *github_pull_request_defaults
     <<: *rh-che-automation-template
 
+- test-for-rollout-token: &test-for-rollout-token
+    name: "test-for-rollout-token"
+    secret-path: 'devtools-osio-ci/qe-osio-token-for-rollout-test'
+    secret-values:
+      - env-var: 'CHE_TESTUSER_OFFLINE__TOKEN'
+        vault-key: 'token'    
+        
+- test-for-rollout-creds: &test-for-rollout-creds
+    name: "test-for-rollout-creds"
+    secret-path: 'devtools-osio-ci/qe-osio-creds-for-rollout-test'
+    secret-values:
+      - env-var: 'CHE_TESTUSER_NAME'
+        vault-key: 'username'
+      - env-var: 'CHE_TESTUSER_PASSWORD'
+        vault-key: 'password'
+    
+- job-template:
+    name: '{ci_project}-{git_repo}-rh-che-rollout-test-{test_url}'
+    triggers:
+        - timed: 'H 3 * * *'
+    wrappers:
+        - vault-secrets:
+          <<: *vault_defaults
+          secrets:
+            - *test-for-rollout-token
+            - *test-for-rollout-creds
+    <<: *rh-che-automation-template
+
+
 - che-functional-tests-template: &che-functional-tests-template
     name: 'che-functional-tests-template'
     wrappers:
@@ -2744,6 +2773,13 @@
             ci_project: 'devtools'
             ci_cmd: 'TARGET="rhel" PR_CHECK_BUILD="true" /bin/bash ./.ci/cico_rhche_prcheck.sh'
             test_url: 'dev.rdu2c.fabric8.io'
+            timeout: '60m'
+        - '{ci_project}-{git_repo}-rh-che-rollout-test-{test_url}':
+            git_organization: redhat-developer
+            git_repo: rh-che
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash ./.ci/cico_rollout_test.sh'
+            test_url: 'devtools-dev.ext.devshift.net'
             timeout: '60m'
         - '{ci_project}-{git_repo}-prcheck-{test_url}-{cluster}':
             git_organization: redhat-developer


### PR DESCRIPTION
This job should test rollout of rh-che on dev cluster. Some credentials are saved in Vault. 