### PR TITLE
Enable f8-tenant service to use fabric8-hub-token secret to be able to create a comments in GH PRs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -483,6 +483,17 @@
     <<: *job_template_defaults
 
 - job-template:
+    name: '{ci_project}-{git_repo}-fabric8-create-comment'
+    wrappers:
+    - vault-secrets:
+        <<: *vault_defaults
+        secrets:
+        - *quay-credentials
+        - *registry-devshift-credentials
+        - *fabric8-hub-token
+    <<: *job_template_defaults
+
+- job-template:
     name: '{ci_project}-{git_repo}-prcheck-publish-artifacts'
     publishers:
       - archive:
@@ -2613,7 +2624,7 @@
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '30m'
             github_hooks: true
-        - '{ci_project}-{git_repo}':
+        - '{ci_project}-{git_repo}-fabric8-create-comment':
             git_organization: fabric8-services
             git_repo: fabric8-tenant
             ci_project: 'devtools'


### PR DESCRIPTION
Added a new template that includes `fabric8-hub-token` secret to enable using it in the build and creating comments in GitHub PRs. Something like this: https://github.com/fabric8-services/fabric8-tenant-jenkins/pull/131#issuecomment-421257056 just with a different message.

The commit that uses this secret can be found here:  https://github.com/fabric8-services/fabric8-tenant/pull/649/commits/9736c77b1529d068b97305225623ccd474ec2fe1