### PR TITLE
removed cancel-builds-on-update from PR checks for saas-openshiftio

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2018,7 +2018,6 @@
             github_hooks: '{github_hooks}'
             status-context: 'ci.centos.org E2E smoke test ({feature_level})'
             trigger-phrase: '.*\[e2e-test-{feature_level}\].*'
-            cancel-builds-on-update: true
             failure-comment: "### $ghprbPullAuthorLoginMention The E2E smoke test with feature level set to '{feature_level}' failed.\n
             | Link | URL |\n
             | ---- | :-: |\n


### PR DESCRIPTION
@riuvshin I didn't realize that we cannot just cancel builds with e2e tests because
1. duffy node would not be released
2. the tests would continue running and at some point would reset the account, new run would fail randomly

I need to find a safer way (https://github.com/fabric8io/fabric8-test/issues/1083)