### PR TITLE
Fix dependabot user name

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -28,7 +28,7 @@
         - chrislessard
         - christianvogt
         - corinnekrych
-        - dependabot
+        - dependabot-bot
         - dgutride
         - DhritiShikhar
         - dipak-pawar


### PR DESCRIPTION
When Dependabot.com creates PRs, the `dependabot-bot` username is used