### PR TITLE
Add vault secrets for 3scale e2e tests

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -282,6 +282,13 @@
       - env-var: 'RECOMMENDER_API_TOKEN'
         vault-key: 'token'
 
+- 3scale-user-key: &3scale-user-key
+    name: "3scale-user-key"
+    secret-path: 'devtools-osio-ci/3scale-user-key'
+    secret-values:
+      - env-var: 'THREE_SCALE_PREVIEW_USER_KEY'
+        vault-key: 'user_key'
+
 - recommender-refresh-token: &recommender-refresh-token
     name: "recommender-refresh-token"
     secret-path: 'devtools-osio-ci/recommender-refresh-token'


### PR DESCRIPTION
We need to set 3scale user_key on ci.centos.org for the Fabric8 Analytics. user_key would be accessible by environment variable `THREE_SCALE_PREVIEW_USER_KEY` e2e tests.

Housekeeping Issue: https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/2399