### PR TITLE
fix(f8-analytics): removes unneeded jobs for vscode extension

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3726,12 +3726,6 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
-        - '{ci_project}-{git_repo}-build-master':
-            git_organization: fabric8-analytics
-            git_repo: fabric8-analytics-vscode-extension
-            ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_build_deploy.sh'
-            timeout: '20m'
         - '{ci_project}-{git_repo}-fabric8-analytics':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-tagger
@@ -3839,12 +3833,6 @@
             git_repo: vscode-osio-auth
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
-            timeout: '20m'
-        - '{ci_project}-{git_repo}-build-master':
-            git_organization: fabric8-analytics
-            git_repo: vscode-osio-auth
-            ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_build_deploy.sh'
             timeout: '20m'
         - '{ci_project}-{git_repo}-fabric8-analytics':
             git_organization: fabric8-analytics


### PR DESCRIPTION
### removes unneeded jobs for vscode extension

- Removes build master for VSCode analytics extension

removed_jobs:
- devtools-fabric8-analytics-vscode-extension-build-master
- devtools-vscode-osio-auth-build-master