### PR TITLE
chore: add new template with fabric8-hub-token to push new client

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1473,6 +1473,24 @@
             - *gpgkeys-for-signing-maven-artefacts
     <<: *job_template_defaults
 
+- job-template:
+    name: '{ci_project}-{git_repo}-build-master-push-client'
+    wrappers:
+      - vault-secrets:
+          <<: *vault_defaults
+          secrets:
+            - *kube-config-dsaas-stg
+            - *quay-credentials
+            - *registry-devshift-credentials
+            - *fabric8-hub-token
+    scm:
+        - git:
+            url: https://github.com/{git_organization}/{git_repo}.git
+            shallow_clone: true
+            branches:
+                - master
+    <<: *job_template_build_defaults
+
 - job:
     name: 'devtools-eclipse-che-build-dockerfiles'
     wrappers:
@@ -3091,7 +3109,7 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             timeout: '25m'
-        - '{ci_project}-{git_repo}-build-master':
+        - '{ci_project}-{git_repo}-build-master-push-client':
             git_repo: fabric8-cluster
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'


### PR DESCRIPTION
We are working on separating client and services from fabric8-services. You can find more details about why at  fabric8-services/fabric8-wit#2063.

Now we need some way using which we should be able to push a newly generated client to a different repository. (e.g. if we have some change in https://github.com/fabric8-services/fabric8-cluster, after successful deployment of fabric8-cluster, we would like to create and push a newly generated client to https://github.com/fabric8-services/fabric8-cluster-client) for which we need `fabric8-hub-token` to be injected as env (`FABRIC8_HUB_TOKEN`), which we can use to push to https://github.com/fabric8-services/fabric8-cluster-client repo.

cc @xcoulon, @alexeykazakov 