### PR TITLE
Create job for compatibility check of Rh-che and latest Che.

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1668,6 +1668,12 @@
             ### *If the build or deployment fails, the artifacts will not be present. Don't panic, just grab a towel.*"
             <<: *github_pull_request_defaults
     <<: *rh-che-automation-template
+    
+- job-template:
+    name: '{ci_project}-{git_repo}-rh-che-compatibility-test-{test_url}'
+    triggers:
+        - timed: 'H 2 * * *'
+    <<: *rh-che-automation-template
 
 - job-template:
     name: '{ci_project}-{git_repo}-prcheck-cleanup'
@@ -2809,11 +2815,18 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
+        - '{ci_project}-{git_repo}-rh-che-compatibility-test-{test_url}':
+            git_organization: redhat-developer
+            git_repo: rh-che
+            ci_project: 'devtools'
+            ci_cmd: 'TARGET="rhel" /bin/bash ./.ci/cico_rhche_compatibility_test.sh'
+            test_url: 'dev.rdu2c.fabric8.io'
+            timeout: '60m'
         - '{ci_project}-{git_repo}-rh-che-prcheck-{test_url}':
             git_organization: redhat-developer
             git_repo: rh-che
             ci_project: 'devtools'
-            ci_cmd: 'TARGET="rhel" PR_CHECK_BUILD="true" /bin/bash ./.ci/cico_rhche_prcheck.sh'
+            ci_cmd: 'TARGET="rhel" /bin/bash ./.ci/cico_rhche_prcheck.sh'
             test_url: 'dev.rdu2c.fabric8.io'
             timeout: '60m'
         - '{ci_project}-{git_repo}-prcheck-cleanup':


### PR DESCRIPTION
Create periodic job that will runs once a day. This job would test Rh-che compatibily with the lastest Che snaphost. It would build an image, push it to quay, deploy image to development cluster and run tests against it.
This job has similar logic as prcheck and reuses some scripts, so the logic was changed here a bit and there is no need to set PR_CHECK_BUILD variable in the job. 