### PR TITLE
Add 3scale user_key to e2e fabric8 analytics secrets

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1012,6 +1012,7 @@
             <<: *vault_defaults
             secrets:
               - *recommender-api-token
+              - *3scale-user-key
               - *recommender-refresh-token
         - ansicolor
     concurrent: false
@@ -1146,6 +1147,7 @@
             secrets:
               - *kube-config-dsaas-stg
               - *recommender-api-token
+              - *3scale-user-key
               - *recommender-refresh-token
         - ansicolor
     concurrent: false


### PR DESCRIPTION
Adding 3scale user_key secret to e2e fabric8 analytics secrets so that it would be accessible by environment variable `THREE_SCALE_PREVIEW_USER_KEY` in e2e tests.