### PR TITLE
Use default template for fabric8-online-docs PR builds

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3176,15 +3176,12 @@
             ci_cmd: '/bin/bash .cico/test.sh'
             timeout: '20m'
             discarder_days: 30
-        - '{ci_project}-{git_repo}-prcheck-publish-artifacts':
+        - '{ci_project}-{git_repo}':
             git_repo: fabric8-online-docs
             git_organization: fabric8io
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_pr_build.sh'
             timeout: '20m'
-            artifacts: './html'
-            allow_empty: true
-            fingerprint: true
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8io
             git_repo: fabric8-test


### PR DESCRIPTION
See https://github.com/fabric8io/fabric8-online-docs/pull/442

Copied from https://github.com/fabric8io/fabric8-online-docs/pull/442#issuecomment-432712588

> The build failed because log shows
> ```
> + docker_login '' '' quay.io
> + local USERNAME=
> + local PASSWORD=
> + local REGISTRY=quay.io
> ```
> 
> We're using the `{ci_project}-{git_repo}-prcheck-publish-artifacts` https://github.com/openshiftio/openshiftio-cico-jobs/blob/master/devtools-ci-index.yaml#L524  job template which doesn't have Quay credentials.
> 
> ~I'll raise a PR on openshiftio-cico-jobs to fix this.~
> PR to use default template https://github.com/openshiftio/openshiftio-cico-jobs/pull/869