### PR TITLE
move fabric8-auth to use *-build-master-push-client and add new job for fabric8-auth-client 

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3132,6 +3132,17 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             timeout: '25m'
+        - '{ci_project}-{git_repo}':
+            git_repo: fabric8-auth-client
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build.sh'
+            timeout: '20m'
+            discarder_days: 30
+        - '{ci_project}-{git_repo}-build-master-update-downstream':
+            git_repo: fabric8-auth-client
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build.sh'
+            timeout: '20m'
         - '{ci_project}-{git_repo}-build-master':
             git_repo: admin-console
             ci_project: 'devtools'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3108,7 +3108,7 @@
             git_repo: saas-hdd
             git_organization: openshiftio
             ci_project: 'devtools'
-        - '{ci_project}-{git_repo}-build-master':
+        - '{ci_project}-{git_repo}-build-master-push-client':
             git_repo: fabric8-auth
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'


### PR DESCRIPTION
**Changes Proposed in this PR**
* use `*-build-master-push-client` template for fabric8-auth where we have `FABRIC8_HUB_TOKEN` available using which we can push newly generated client.
* add new job for fabric8-auth-client