### PR TITLE
Moved vault wrapper secrets to parent template.

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1769,6 +1769,7 @@
           <<: *vault_defaults
           secrets:
             - *quay-credentials
+            - *kube-config-dsaas-stg
       - che_functional_tests_credentials_wrapper-{type}-{test_url}-{cluster}
     concurrent: false
     <<: *job_template_defaults
@@ -1825,11 +1826,6 @@
             url: https://{github_user}@github.com/{git_organization}/{git_repo}.git
             branches:
                 - origin/master
-    wrappers:
-    - vault-secrets:
-        <<: *vault_defaults
-        secrets:
-          - *kube-config-dsaas-stg
     beforeGetNode: |
         #Wait for correct rh-che version to be deployed & running on prod-preview
         isPodRunning () (


### PR DESCRIPTION
Adding `kube-config-dsaas-stg` wrapper to
`{ci_project}-{git_repo}-after-rh-che-build-{test_url}` template
overrides wrappers from parent template
(`che-functional-tests-template`). This commit moves the secret to
parent template.

Signed-off-by: Radim Hopp <rhopp@redhat.com>