### PR TITLE
Update branches to run tests against prod and prod-preview

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4296,7 +4296,7 @@
             osio_token: be32035b-cdd2-441b-ab27-93d023feeb1d
             osio_creds: b310559d-91c5-469c-bb35-fc9b8333e619
             ci_project: 'devtools'
-            branch: 'UI-tests'
+            branch: 'prod-preview-tests'
             ee_test_start_time: '0 * * * *'
             ci_cmd: '/bin/bash cico_test_prod.sh --prod-preview'
             timeout: '40m'
@@ -4308,7 +4308,7 @@
             osio_creds: e53d9045-2500-498a-936f-3ecf323af800
             ci_project: 'devtools'
             test_url: 'openshift.io'
-            branch: 'UI-tests'
+            branch: 'prod-tests'
             ee_test_start_time: '0 */4 * * *'
             ci_cmd: '/bin/bash cico_test_prod.sh'
             timeout: '40m'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4566,7 +4566,7 @@
             ci_project: 'devtools'
             branch: 'master'
             ee_test_start_time: '35 */2 * * *'
-            ci_cmd: 'cd ee_tests && /bin/bash cico_run_e2e_tests.sh'
+            ci_cmd: 'cd ee_tests && /bin/bash TEST_SUITE=$test_suite TEST_URL=$test_url ./cico_run_e2e_tests.sh'
             timeout: '40m'
         - 'devtools-test-e2e-{test_url}-{test_suite}':
             git_organization: fabric8io
@@ -4578,5 +4578,5 @@
             ci_project: 'devtools'
             branch: 'master'
             ee_test_start_time: '40 */4 * * *'
-            ci_cmd: 'cd ee_tests && /bin/bash cico_run_e2e_tests.sh'
+            ci_cmd: 'cd ee_tests && /bin/bash TEST_SUITE=$test_suite TEST_URL=$test_url ./cico_run_e2e_tests.sh'
             timeout: '40m'


### PR DESCRIPTION
This PR updates branches for jobs - 
- devtools-test-e2e-prod-preview.openshift.io-planner-functional-tests
- devtools-test-e2e-openshift.io-planner-functional-tests

And also updates jobs -
- devtools-test-e2e-openshift.io-planner
- devtools-test-e2e-prod-preview.openshift.io-planner

Why?
Sometimes production/prod-preview is behind the master branch and tests start failing.
