### PR TITLE
Increase timeout for golang-insights jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3810,7 +3810,7 @@
             git_repo: f8a-golang-insights
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
-            timeout: '20m'
+            timeout: '30m'
             registry: 'quay.io'
             image_name: 'openshiftio/fabric8-analytics-f8a-golang-insights'
         - '{ci_project}-{git_repo}-f8a-build-master':
@@ -3821,7 +3821,7 @@
             saas_git: saas-analytics
             deployment_units: 'f8a-golang-insights'
             deployment_configs: 'f8a-golang-insights'
-            timeout: '20m'
+            timeout: '60m'
             extra_target: rhel
         - '{ci_project}-{git_repo}-fabric8-analytics-pylint':
             git_repo: f8a-golang-insights


### PR DESCRIPTION
The Golang job requires pandas as a dependency which takes around 10 minutes by itself to compile. As a result the job times out during the image push phase, increasing timeout by 10 minutes. Since the master build runs end to end tests and also builds a RHEL image, increasing the timeout there to 60 minutes.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>