### PR TITLE
Increased timeout of rhche prchek depbuild job

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3006,7 +3006,7 @@
             git_repo: rh-che
             ci_project: 'devtools'
             ci_cmd: '/bin/bash ./.ci/cico_build_prcheck_dep.sh'
-            timeout: '60m'
+            timeout: '120m'
         - '{ci_project}-{git_repo}-periodical-{test_url}-{cluster}':
             git_organization: redhat-developer
             git_repo: che-functional-tests


### PR DESCRIPTION
Increased timeout as the job was just barely not able to push the built image (leaving some header room)

HK issue: https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/2461