### PR TITLE
Setup recipients for Analytics repositories

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -618,6 +618,11 @@
             - fabric8-analytics
           success-comment: "$ghprbPullAuthorLoginMention Your image is available in the registry: `docker pull {registry}/{image_name}:SNAPSHOT-PR-$ghprbPullId`"
           <<: *github_pull_request_defaults
+    publishers:
+        - email:
+            recipients: ptisnovs@redhat.com devtools-bayesian@redhat.com
+            notify-every-unstable-build: true
+            send-to-individuals: true
     <<: *job_template_defaults
 
 - job-template:
@@ -1102,6 +1107,11 @@
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload-tests
             $ssh_cmd -t "cd payload-tests/integration-tests && /bin/bash cico_run_tests.sh"
+    publishers:
+        - email:
+            recipients: ptisnovs@redhat.com devtools-bayesian@redhat.com
+            notify-every-unstable-build: true
+            send-to-individuals: true
     <<: *job_template_defaults
 
 - job-template:


### PR DESCRIPTION
Hi guys,
the analytics team needs to be informed about CI failures. TBH I don't know precisely how to setup CI notifications properly in Almighty file, so this PR might not be correct. Anyway, could anybody please look at it? Thank you in advance.

Related Q.: is it possible to send a message to selected Mattermost channel as well (in case of failures on CI?)