### PR TITLE
chore: skip deployment by removing saas_git option

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2829,7 +2829,6 @@
             git_repo: toolchain-operator
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
-            saas_git: saas-openshiftio
             timeout: '10m'
             extra_target: rhel
         - '{ci_project}-{git_repo}':


### PR DESCRIPTION
**Changes Proposed in this PR**

In the case of operator we need to build a container image, but no need to deploy it on prod-preview as it'll be used when an end user is installing it from the marketplace.

So to skip deployment, removing  `saas_git`, so build script will take it's value as default and don't execute logic of deployment. see https://github.com/openshiftio/openshiftio-cico-jobs/blob/master/devtools-ci-index.yaml#L772