### PR TITLE
set master branch as build branch for tenant repo

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2919,7 +2919,6 @@
             saas_git: saas-openshiftio
             timeout: '10m'
             extra_target: rhel
-            build_branch: develop
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-services
             git_repo: fabric8-toggles


### PR DESCRIPTION
The testing of the new functionality (that was in `develop` branch) is done. I'm going to [merge](https://github.com/fabric8-services/fabric8-tenant/pull/747) the changes to `master` so I need to set the master branch back as the build branch