### PR TITLE
Increasing timeout for che-dockerfiles to 180 minutes

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1661,7 +1661,7 @@
             ssh_cmd="ssh $sshopts $CICO_hostname"
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-            /usr/bin/timeout 90m $ssh_cmd -t "cd payload && /bin/bash cico_build_publish_images.sh"
+            /usr/bin/timeout 180m $ssh_cmd -t "cd payload && /bin/bash cico_build_publish_images.sh"
             rtn_code=$?
             if [[ $rtn_code -eq 124 ]]; then
                echo "BUILD TIMEOUT";


### PR DESCRIPTION
related issue - https://github.com/redhat-developer/rh-che/issues/1234
CI is failing with timeout - https://ci.centos.org/job/devtools-eclipse-che-build-dockerfiles/