### PR TITLE
Rh-che: remove unused parameter.

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -290,8 +290,6 @@
         vault-key: 'username'
       - env-var: 'PASSWORD'
         vault-key: 'password'
-      - env-var: 'OFFLINE_TOKEN'
-        vault-key: 'token'
       - env-var: 'EMAIL'
         vault-key: 'email'
 
@@ -303,8 +301,6 @@
         vault-key: 'username'
       - env-var: 'PASSWORD'
         vault-key: 'password'
-      - env-var: 'OFFLINE_TOKEN'
-        vault-key: 'token'
       - env-var: 'EMAIL'
         vault-key: 'email'
 
@@ -316,8 +312,6 @@
         vault-key: 'username'
       - env-var: 'PASSWORD'
         vault-key: 'password'
-      - env-var: 'OFFLINE_TOKEN'
-        vault-key: 'token'
       - env-var: 'EMAIL'
         vault-key: 'email'
         


### PR DESCRIPTION
Parameter OFFLINE_TOKEN is obsolete and is not used in tests. It is not set in a Vault to. Removing it.