### PR TITLE
Fix saas prcheck

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2752,7 +2752,7 @@
 
             $ssh_cmd yum -y install rsync
 
-            rsync -e "ssh $sshopts" -Ha $(pwd)/rhche/ $CICO_hostname:payload \
+            rsync -e "ssh $sshopts" -Ha $(pwd)/rhche/ $(pwd)/.env-toolkit $CICO_hostname:payload \
             && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
             rtn_code=$?
             if [ $rtn_code -eq 0 ]; then


### PR DESCRIPTION
As the last change in PR https://github.com/openshiftio/openshiftio-cico-jobs/pull/1004 we changed rsync to sync only $(pwd)/rh-che folder because this is the locatoin where all scripts are located. But as far as ./env-toolkit is in parent folder, we have no access to credentials saved in Vault. This PR adds the ```./env-toolkit``` to rsync.