### PR TITLE
Add job for building docker image of Che Devfile Registry

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4412,6 +4412,14 @@
             saas_git: saas-openshiftio
             timeout: '10m'
             extra_target: rhel
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: eclipse
+            git_repo: che-devfile-registry
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build.sh'
+            saas_git: saas-openshiftio
+            timeout: '10m'
+            extra_target: rhel
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-lsp-server


### PR DESCRIPTION
This PR add job for building docker image of [Che Devfile Registry](https://github.com/eclipse/che-devfile-registry).

It's similar to [Plugin Registry](https://github.com/eclipse/che-plugin-registry) and `cici_build.sh` script is the same (except target dockerhub repository name and used Dockerfile)

PR for setting up job for Che Plugin Registry https://github.com/openshiftio/openshiftio-cico-jobs/pull/748

I'm not sure that it will work after merging, maybe some repository settings are missing from Devfile Registry repo, like webhooks. Any assistance is welcome.