### PR TITLE
fix: adds dependabot-preview account to admins

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -34,6 +34,7 @@
         - corinnekrych
         - davidfestal
         - dependabot[bot]
+        - dependabot-preview[bot] 
         - dgutride
         - DhritiShikhar
         - dipak-pawar


### PR DESCRIPTION
After GH acquisition of dependabot, as they are integration more closely, old account opening PRs has been changed to dependabot-preview[bot] 

This adds aforementioned account to the admin list so the PRs are automatically tested.