### PR TITLE
Increase timeouts for RH-Che jobs.

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3120,7 +3120,7 @@
             ci_project: 'devtools'
             ci_cmd: 'TARGET="rhel" /bin/bash ./.ci/cico_rhche_prcheck.sh'
             test_url: 'dev.rdu2c.fabric8.io'
-            timeout: '60m'
+            timeout: '75m'
         - '{ci_project}-{git_repo}-prcheck-cleanup':
             git_organization: redhat-developer
             git_repo: rh-che
@@ -3188,7 +3188,7 @@
             ci_project: 'devtools'
             ci_cmd: 'export HOST_URL="che.prod-preview.openshift.io" && source ./functional-tests/devscripts/prepare_env.sh && ./functional-tests/devscripts/run_tests.sh'
             env: 'prod-preview'
-            timeout: '50m'
+            timeout: '60m'
             cluster: '2a'
         - '{ci_project}-{git_repo}-periodic-{env}-{cluster}':
             git_organization: redhat-developer
@@ -3196,7 +3196,7 @@
             ci_project: 'devtools'
             ci_cmd: 'export HOST_URL="che.openshift.io" && source ./functional-tests/devscripts/prepare_env.sh && ./functional-tests/devscripts/run_tests.sh'
             env: 'prod'
-            timeout: '50m'
+            timeout: '60m'
             cluster: '2aProd'
         - '{ci_project}-{git_repo}-periodic-{env}-{cluster}':
             git_organization: redhat-developer
@@ -3204,7 +3204,7 @@
             ci_project: 'devtools'
             ci_cmd: 'export HOST_URL="che.openshift.io" && source ./functional-tests/devscripts/prepare_env.sh && ./functional-tests/devscripts/run_tests.sh'
             env: 'prod'
-            timeout: '50m'
+            timeout: '60m'
             cluster: '2'
         - '{ci_project}-{git_repo}-periodic-{env}-{cluster}':
             git_organization: redhat-developer
@@ -3212,7 +3212,7 @@
             ci_project: 'devtools'
             ci_cmd: 'export HOST_URL="che.openshift.io" && source ./functional-tests/devscripts/prepare_env.sh && ./functional-tests/devscripts/run_tests.sh'
             env: 'prod'
-            timeout: '50m'
+            timeout: '60m'
             cluster: '1b'
         - '{ci_project}-{git_repo}-periodic-{env}-{cluster}':
             git_organization: redhat-developer
@@ -3220,7 +3220,7 @@
             ci_project: 'devtools'
             ci_cmd: 'export HOST_URL="che.openshift.io" && source ./functional-tests/devscripts/prepare_env.sh && ./functional-tests/devscripts/run_tests.sh'
             env: 'prod'
-            timeout: '50m'
+            timeout: '60m'
             cluster: '1a'
         - '{ci_project}-{git_repo}-build-che-credentials-{branch}':
             git_organization: redhat-developer


### PR DESCRIPTION
Increase timeouts for RH-Che PR check (from 60 to 75 minutes) and for periodic jobs (from 50 to 60 minutes). 