### PR TITLE
che #13813: Adding new '{ci_project}-{git_repo}-nightly' job template and brand-new nightly job for 'che-devfile-registry'

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2110,6 +2110,25 @@
     <<: *rhche-route-tests-template
 
 - job-template:
+    name: '{ci_project}-{git_repo}-nightly'
+    wrappers:
+      - vault-secrets:
+          <<: *vault_defaults
+          secrets:
+            - *quay-eclipse-che-credentials
+    triggers:
+        - timed: '*/30 * * * *'
+    publishers:
+        - email:
+            recipients: ibuziuk@redhat.com mloriedo@redhat.com amisevsk@redhat.com vparfono@redhat.com
+    scm:
+        - git:
+            url: https://{github_user}@github.com/{git_organization}/{git_repo}.git
+            branches:
+                - origin/master
+    <<: *job_template_defaults
+
+- job-template:
     name: '{ci_project}-{git_repo}-flaky-{env}-{cluster}'
     triggers:
         - timed: 'H 3,9,15,21 * * *'
@@ -4485,6 +4504,12 @@
             saas_git: saas-openshiftio
             timeout: '10m'
             extra_target: rhel
+        - '{ci_project}-{git_repo}-nightly':
+            git_organization: eclipse
+            git_repo: che-devfile-registry
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_nightly.sh'
+            timeout: '30m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-lsp-server


### PR DESCRIPTION
Related che-devfile-registry PR - https://github.com/eclipse/che-devfile-registry/pull/35
Related che issue - https://github.com/eclipse/che/issues/13813