### PR TITLE
[RH-Che] Fix archiving artefacts

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2844,7 +2844,7 @@
 
             $ssh_cmd yum -y install rsync
 
-            rsync -e "ssh $sshopts" -Ha $(pwd)/rhche/ $(pwd)/env-toolkit $(pwd)/jenkins-env.json $CICO_hostname:payload \
+            rsync -e "ssh $sshopts" -Ha $(pwd)/rhche/ $(pwd)/artifacts.key $(pwd)/env-toolkit $(pwd)/jenkins-env.json $CICO_hostname:payload \
             && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
             rtn_code=$?
             if [ $rtn_code -eq 0 ]; then


### PR DESCRIPTION
Add artifacts.key to rsync. Now we would be able to push artefacts to http://artifacts.ci.centos.org.