### PR TITLE
che-13953: Adding GitHub trigger to the '{ci_project}-{git_repo}-release' job template

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2147,6 +2147,8 @@
             shallow_clone: true
             branches:
                 - release
+    triggers:
+        - github
     <<: *job_template_defaults
 
 - job-template:


### PR DESCRIPTION
Job template for devfile registry has been created, but looks like it is missig GitHub trigger - https://ci.centos.org/job/devtools-che-devfile-registry-release/