### PR TITLE
Adding extra credentials to have a possibility to push rhel images to 'https://quay.io/organization/openshiftio/' during the '{ci_project}-{git_repo}-release' CI build

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2137,6 +2137,7 @@
       - vault-secrets:
           <<: *vault_defaults
           secrets:
+            - *quay-credentials
             - *quay-eclipse-che-credentials
     publishers:
         - email:


### PR DESCRIPTION
Pushing images to https://quay.io/organization/openshiftio/ require a different set of credentials