### PR TITLE
Adding 'job_template_build_defaults' to the release template in order…

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2155,7 +2155,7 @@
                 - release
     triggers:
         - github
-    <<: *job_template_defaults
+    <<: *job_template_build_defaults
 
 - job-template:
     name: '{ci_project}-{git_repo}-flaky-{env}-{cluster}'


### PR DESCRIPTION
I noticed that https://ci.centos.org/job/devtools-che-devfile-registry-release/ does not build rhel based images and looks like changing `job_template_defaults` to `job_template_build_defaults` should do the trick