### PR TITLE
enable manifest-bouncer

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -9,6 +9,7 @@
     discarder_days: -1
     discarder_num: -1
     build_branch: master
+    manifest_bouncer_tag: d21c96f
 
 - admin_list_defaults: &admin_list_defaults
     name: 'admin_list_defaults'
@@ -2314,6 +2315,63 @@
         - github
     builders:
         - shell: |
+            # testing out the cico client
+            set +e
+
+            export CICO_API_KEY=$(cat ~/duffy.key )
+
+            # get node
+            n=1
+            while true
+            do
+                cico_output=$(cico node get -f value -c ip_address -c comment)
+                if [ $? -eq 0 ]; then
+                    read CICO_hostname CICO_ssid <<< $cico_output
+                    if  [ ! -z "$CICO_hostname" ]; then
+                        # we got hostname from cico
+                        break
+                    fi
+                    echo "'cico node get' succeed, but can't get hostname from output"
+                fi
+                if [ $n -gt 15 ]; then
+                    # give up after 15 tries
+                    echo "giving up on 'cico node get'"
+                    exit 1
+                fi
+                echo "'cico node get' failed, trying again in 60s ($n/15)"
+                n=$[$n+1]
+                sleep 60
+            done
+
+            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+            ssh_cmd="ssh $sshopts $CICO_hostname"
+
+            if [ -n "${{ghprbTargetBranch}}" ]; then
+                git rebase --preserve-merges origin/${{ghprbTargetBranch}}
+                rtn_code=$?
+                if [ $rtn_code -ne 0 ]; then
+                    echo "The branch can not be rebased onto origin/${{ghprbTargetBranch}}."
+                    exit $rtn_code
+                fi
+            else
+                echo "Not a PR build, using master"
+            fi
+
+
+            $ssh_cmd -t "yum install -y docker && systemctl start docker"
+
+            ENVIRONMENT=production PATH=$PATH:~/.local/bin DRY_RUN=true /bin/bash ~/saasherder/fetch_and_apply.sh
+            CONTEXTS=$(PATH=$PATH:~/.local/bin saasherder config get-contexts)
+            for c in `echo $CONTEXTS`; do
+                DIR=$(readlink -f $c-20* | tail -1)
+                for f in `ls $DIR`; do
+                    python ~/saasherder/check_image.py $DIR/$f '{image_pattern}'
+                    cat $f | $ssh_cmd docker run --rm -i quay.io/app-sre/manifest-bouncer:{manifest_bouncer_tag} -
+                done
+            done
+
+            cico node done $CICO_ssid
+
             set -ex
             ENVIRONMENT=production PATH=$PATH:~/.local/bin /bin/bash ~/saasherder/fetch_and_apply.sh
 
@@ -2327,15 +2385,64 @@
           - *kube-config-dsaas-stg
     builders:
         - shell: |
+            # testing out the cico client
+            set +e
+
+            export CICO_API_KEY=$(cat ~/duffy.key )
+
+            # get node
+            n=1
+            while true
+            do
+                cico_output=$(cico node get -f value -c ip_address -c comment)
+                if [ $? -eq 0 ]; then
+                    read CICO_hostname CICO_ssid <<< $cico_output
+                    if  [ ! -z "$CICO_hostname" ]; then
+                        # we got hostname from cico
+                        break
+                    fi
+                    echo "'cico node get' succeed, but can't get hostname from output"
+                fi
+                if [ $n -gt 15 ]; then
+                    # give up after 15 tries
+                    echo "giving up on 'cico node get'"
+                    exit 1
+                fi
+                echo "'cico node get' failed, trying again in 60s ($n/15)"
+                n=$[$n+1]
+                sleep 60
+            done
+
+            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+            ssh_cmd="ssh $sshopts $CICO_hostname"
+
+            if [ -n "${{ghprbTargetBranch}}" ]; then
+                git rebase --preserve-merges origin/${{ghprbTargetBranch}}
+                rtn_code=$?
+                if [ $rtn_code -ne 0 ]; then
+                    echo "The branch can not be rebased onto origin/${{ghprbTargetBranch}}."
+                    exit $rtn_code
+                fi
+            else
+                echo "Not a PR build, using master"
+            fi
+
             set -ex
+
+            $ssh_cmd -t "yum install -y docker && systemctl start docker"
+
             ENVIRONMENT=production PATH=$PATH:~/.local/bin DRY_RUN=true /bin/bash ~/saasherder/fetch_and_apply.sh
             CONTEXTS=$(PATH=$PATH:~/.local/bin saasherder config get-contexts)
             for c in `echo $CONTEXTS`; do
                 DIR=$(readlink -f $c-20* | tail -1)
                 for f in `ls $DIR`; do
                     python ~/saasherder/check_image.py $DIR/$f '{image_pattern}'
+                    cat $f | $ssh_cmd docker run --rm -i quay.io/app-sre/manifest-bouncer:{manifest_bouncer_tag} -
                 done
             done
+
+            cico node done $CICO_ssid
+
     <<: *job_template_defaults
 
 - job:

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2299,6 +2299,7 @@
 
 - job-template:
     name: '{ci_project}-{git_repo}-promote-to-prod'
+    image_pattern: ''
     defaults: global
     node: devtools
     disabled: '{obj:disabled}'


### PR DESCRIPTION
The purpose of this PR is to be able to perform checks on the manifests that
will be applied in production.

The checks will be performed by [manifest-bouncer](/app-sre/manifest-bouncer/).
This tools analyzes OpenShift/k8s templates and returns an error if the
manifests don't pass the tests.

This PR modifies the `promote-to-prod` and the `promote-to-prod-test` job
templates. Both job templates run in the slave node, and this slave node doesn't
have docker available. We need docker to run manifest-bouncer because it has
been written in python3 and the slave is running CentOS-7.

For both templates the following additions happen:

- A cico node is requested: https://github.com/openshiftio/openshiftio-cico-jobs/pull/1068/files#diff-a0fd432ddaac45438209cf6e0a7298c0R2319-R2345
- In `promote-to-prod-test` the branch is rebased to ensure that there are no conflicts
- fetch_and_apply.sh with dry-run option is executed which generates one directory per context where the rendered templates are written
- We iterate through all the rendered template directories and through all the files and run manifest-bouncer in the duffy node (passing it via STDIN)
- As before the PR we check the image availability with `check_image.py`
- If the above works, then in the case of `promote-to-prod` the real `fetch_and_apply.sh` is called.
 
This is the list of affected jobs:

- devtools-saas-analytics-promote-to-prod-test
- devtools-saas-hdd-promote-to-prod-test
- devtools-saas-launchpad-promote-to-prod-test
- devtools-saas-openshiftio-promote-to-prod-test
- devtools-saas-analytics-promote-to-prod
- devtools-saas-hdd-promote-to-prod
- devtools-saas-launchpad-promote-to-prod
- devtools-saas-openshiftio-promote-to-prod
