### PR TITLE
increase the f8-wit coverage job timeout

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3036,7 +3036,7 @@
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
-            timeout: '3h'
+            timeout: '4h'
             discarder_days: 30
         - '{ci_project}-{git_repo}-e2e':
             git_repo: fabric8-wit


### PR DESCRIPTION
increase the f8-wit coverage job timeout to 4h because last two runs failed because of reaching the timeout. https://ci.centos.org/job/devtools-fabric8-wit-coverage/
The last successful run took 2:40 which isn't significantly shorter than the current timeout is (3h) 