### PR TITLE
che #14357 Adding 'master', 'nightly', 'release' CI for 'che-machine-exec' plugin

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4462,6 +4462,24 @@
             discarder_days: 30
         - '{ci_project}-{git_repo}-build-master':
             git_organization: eclipse
+            git_repo: che-machine-exec
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_ci.sh'
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-nightly':
+            git_organization: eclipse
+            git_repo: che-machine-exec
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_nightly.sh'
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-release':
+            git_organization: eclipse
+            git_repo: che-machine-exec
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_release.sh'
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: eclipse
             git_repo: che-plugin-registry
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_ci.sh'


### PR DESCRIPTION
Related Che issue - https://github.com/eclipse/che/issues/14357