### PR TITLE
Add git-scm to rh-che-compatibility-test

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1874,10 +1874,9 @@
     triggers:
         - timed: 'H 2 * * *'
     scm:
-        - git:
-            url: https://{github_user}@github.com/{git_organization}/{git_repo}.git
-            branches:
-                - origin/master
+        - git-scm:
+            git_url: 'https://{github_user}@github.com/{git_organization}/{git_repo}.git'
+            git_basedir: ''
     <<: *rh-che-automation-template
 
 - job-template:


### PR DESCRIPTION
Enabling git-scm for rh-che-compatibility-test. Not having the credentials was preventing us from pushing branches.

Signed-off-by: Tibor Dancs <tdancs@redhat.com>

This change is required, because we were unable to push a branch into rh-che repository from our automation scripts. This is necessary in order to allow us to rebase rh-che onto the latest nightly upstream and verify that nothing is getting broken.