### PR TITLE
Fix rh-che-automation-template missing credentials for almighty-bot account

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1824,6 +1824,7 @@
             - *rh-che-automation-quay-secret
             - *fabric8-hub-token
             - *qe-osio-dev-cluster-SA-token
+      - almighty-git-push
     <<: *job_template_defaults
 
 - rh-che-automation-depbuild-template: &rh-che-automation-depbuild-template
@@ -1941,6 +1942,15 @@
       - rhche_credentials_wrapper-flaky-{cluster}
     concurrent: false
     <<: *job_template_defaults
+
+- wrapper:
+    name: almighty-git-push
+    wrappers:
+        - credentials-binding:
+            - username-password-separated:
+                credential-id: c4872223-4024-4cd4-8e09-1bbdc7d6e971
+                username: ALMIGHTY_GIT_USER
+                password: ALMIGHTY_GIT_PASSWORD
 
 - wrapper:
     name: 'rhche_credentials_wrapper-flaky-2'


### PR DESCRIPTION
Trying a new fix which should allow us to manually configure a remote to allow pushing into the repository.