### PR TITLE
exit on error in oc apply

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -810,6 +810,10 @@
             saasherder --environment $SAAS_ENV label --output-dir $GIT_REPO-processed --saas-repo-url $SAAS_GIT $SAAS_SERVICE_NAME > label_selector
             oc --server="$KUBE_SERVER" --token="$KUBE_TOKEN" apply -f $GIT_REPO-processed/$SAAS_SERVICE_NAME.yaml -n $PRJ_NAME
             rtn_code=$?
+            if [ $rtn_code -ne 0 ]; then
+                echo "error during oc apply"
+                exit $rtn_code
+            fi
             label_selector=$(cat label_selector)
             resources_to_delete=$(oc --server="$KUBE_SERVER" --token="$KUBE_TOKEN" get $SAASHERDER_OBJECT_WHITELIST -o name -l "$label_selector" -n $PRJ_NAME)
             for r in $resources_to_delete; do


### PR DESCRIPTION
This PR adds a handle for a case when `oc apply` failed, so that resources will not be deleted when new ones are not created.
example: https://ci.centos.org/job/devtools-rh-che-build-che-credentials-master/426/console

covers https://jira.coreos.com/browse/APPSRE-1235