### PR TITLE
Change che-theia job 'build_brunch'

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4351,6 +4351,7 @@
             git_organization: eclipse
             git_repo: che-theia
             branch: cico_build
+            build_branch: cico_build
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_master.sh'
             timeout: '2h'


### PR DESCRIPTION
For transition period I need to polish my build scripts, so I want to change build branch, until I finish work on build scripts.