### PR TITLE
Use master branch for che-theia build jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4432,15 +4432,12 @@
         - '{ci_project}-{git_repo}-che-nightly':
             git_organization: eclipse
             git_repo: che-theia
-            branch: cico_build
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_nightly.sh'
             timeout: '2h'
         - '{ci_project}-{git_repo}-che-build-master':
             git_organization: eclipse
             git_repo: che-theia
-            branch: cico_build
-            build_branch: cico_build
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_master.sh'
             timeout: '2h'


### PR DESCRIPTION
Now scrips are ready, so switching jobs to `master` branch of `che-theia` repository