### PR TITLE
Change build template for obtain artifacts.key file

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -68,7 +68,7 @@
         - miteshvp
         - mmclanerh
         - msrb
-        - musienko-maxim 
+        - musienko-maxim
         - neugens
         - nimishamukherjee
         - nurali-techie
@@ -267,7 +267,7 @@
     secret-values:
       - env-var: 'CHE_GITHUB_SSH_KEY'
         vault-key: 'che-github-ssh-key'
-      
+
 - osiotestmachine-clean-up-gh-token: &osiotestmachine-clean-up-gh-token
     name: "osiotestmachine-clean-up-gh-token"
     secret-path: 'devtools-osio-ci/osiotestmachine-clean-up-gh-token'
@@ -1606,12 +1606,33 @@
     wrappers:
     - vault-secrets:
         <<: *vault_defaults
-        secrets: 
+        secrets:
             - *quay-eclipse-che-credentials
             - *che-bot-github-credentials
             - *eclipse-che-oss-sonatype
 
     <<: *job_template_build_master
+
+- eclipse-che-automation-template: &eclipse-che-automation-template
+    name: "eclipse-che-automation-template"
+    concurrent: false
+    wrapper:
+      - vault-secrets:
+        <<: *vault_defaults
+        secret:
+            - *quay-eclipse-che-credentials
+    <<: *job_template_defaults
+    
+- job-template:
+    name: '{ci_project}-{git_repo}-che-nightly-test-master'
+    wrappers:
+    - vault-secrets:
+        <<: *vault_defaults
+        secrets: 
+            - *eclipse-che-oss-sonatype
+
+    <<: *eclipse-che-automation-template
+
 
 - job-template:
     name: '{ci_project}-{git_repo}-che-nightly'
@@ -4347,6 +4368,24 @@
             git_repo: che-parent
             ci_project: 'devtools'
             ci_cmd: '/bin/bash .ci/cico_build.sh'
+            timeout: '10m'      
+        - '{ci_project}-{git_repo}-che-nightly':
+            git_organization: eclipse
+            git_repo: che-docs
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash .ci/cico_build_nightly.sh'
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-che-release':
+            git_organization: eclipse
+            git_repo: che-docs
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash .ci/cico_build_release.sh'
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-che-build-master':
+            git_organization: eclipse
+            git_repo: che-docs
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash .ci/cico_build.sh'
             timeout: '10m'
         - '{ci_project}-{git_repo}-che-nightly':
             git_organization: eclipse
@@ -4365,7 +4404,7 @@
             git_repo: che
             ci_project: 'devtools'
             ci_cmd: '/bin/bash .ci/cico_build.sh'
-            timeout: '1h'       
+            timeout: '1h'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: eclipse
             git_repo: che-machine-exec
@@ -4413,6 +4452,25 @@
             build_branch: release-preview
             extra_target: rhel
             timeout: '30m'
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: eclipse
+            git_repo: che-plugin-broker
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash .cico/cico_build_ci.sh'
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-nightly':
+            git_organization: eclipse
+            git_repo: che-plugin-broker
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash .cico/cico_build_nightly.sh'
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-release':
+            git_organization: eclipse
+            git_repo: che-plugin-broker
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash .cico/cico_build_release.sh'
+            timeout: '10m'
+            extra_target: rhel
         - '{ci_project}-{git_repo}-build-master':
             git_organization: eclipse
             git_repo: che-devfile-registry
@@ -4478,6 +4536,14 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_release.sh'
             timeout: '2h'
+        - '{ci_project}-{git_repo}-che-nightly-test-master':
+            git_organization: eclipse
+            git_repo: che
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash tests/.infra/centos-ci/cico_build.sh'
+            branch: 'cico-nightly-test'
+            build_branch: 'cico-nightly-test'
+            timeout: '3h'       
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-lsp-server


### PR DESCRIPTION
After launching `happy path` test we need to use `artifact.key`file for correct rsync. Previous template did not store the key. According to this problem we change the template for resolving this one.