### PR TITLE
WIP: Add job to start java E2E tests on Eclipse Che release candidate

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1668,12 +1668,8 @@
     <<: *eclipse-che-automation-template
 
 - job-template:
-    name: '{ci_project}-{git_repo}-che-integration-tests-rc-temporary'
-    wrappers:
-    - vault-secrets:
-        <<: *vault_defaults
-        secrets: 
-            - *quay-eclipse-che-credentials
+    name: '{ci_project}-{git_repo}-rc-integration-tests'
+
     scm:
         - git:
             url: https://github.com/{git_organization}/{git_repo}.git
@@ -4609,12 +4605,12 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash tests/.infra/centos-ci/cico_pr_test.sh'
             timeout: '3h'
-        - '{ci_project}-{git_repo}-che-integration-tests-rc-temporary':
+        - '{ci_project}-{git_repo}-rc-integration-tests':
             git_organization: eclipse
             git_repo: che
             ci_project: 'devtools'
             ci_cmd: '/bin/bash tests/.infra/centos-ci/cico_rc_test.sh'
-            timeout: '3h'
+            timeout: '1h'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-lsp-server

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1668,6 +1668,24 @@
     <<: *eclipse-che-automation-template
 
 - job-template:
+    name: '{ci_project}-{git_repo}-che-integration-tests-rc-temporary'
+    wrappers:
+    - vault-secrets:
+        <<: *vault_defaults
+        secrets: 
+            - *quay-eclipse-che-credentials
+    scm:
+        - git:
+            url: https://github.com/{git_organization}/{git_repo}.git
+            shallow_clone: true
+            branches:
+                - cico-rc-test
+    triggers:
+        - github
+
+    <<: *eclipse-che-automation-template
+
+- job-template:
     name: '{ci_project}-{git_repo}-che-nightly'
     concurrent: false
     wrappers:
@@ -4590,6 +4608,12 @@
             git_repo: che
             ci_project: 'devtools'
             ci_cmd: '/bin/bash tests/.infra/centos-ci/cico_pr_test.sh'
+            timeout: '3h'
+        - '{ci_project}-{git_repo}-che-integration-tests-rc-temporary':
+            git_organization: eclipse
+            git_repo: che
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash tests/.infra/centos-ci/cico_rc_test.sh'
             timeout: '3h'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics


### PR DESCRIPTION
* Add the _devtools-che-rc-integration-tests_ job for starting java selenium E2E tests on Eclipse Che release candidate