### PR TITLE
Do not build RHEL based Plugin Broker images

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -4522,7 +4522,6 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash .cico/cico_build_release.sh'
             timeout: '10m'
-            extra_target: rhel
         - '{ci_project}-{git_repo}-build-master':
             git_organization: eclipse
             git_repo: che-devfile-registry


### PR DESCRIPTION
We just figure out that Plugin Broker RHEL based images are not used anywhere.
So, we don't need extra target at this stage.