### PR TITLE
Add sonatype creds for building CHE project-s

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1659,6 +1659,7 @@
         <<: *vault_defaults
         secrets: 
             - *quay-eclipse-che-credentials
+            - *eclipse-che-oss-sonatype
     scm:
         - git:
             url: https://github.com/{git_organization}/{git_repo}.git


### PR DESCRIPTION
* We need build the CHE project for nightly testing, Correct maven  build need sonatype credentials.