### PR TITLE
Add sonatype creds. to eclipse-che-automation-template

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1623,6 +1623,7 @@
         <<: *vault_defaults
         secrets:
             - *quay-eclipse-che-credentials
+            - *eclipse-che-oss-sonatype
 
     <<: *job_template_defaults
 


### PR DESCRIPTION
We need have the sonatype creds in the eclipse-che-automation-template for building upstream che with maven