### PR TITLE
Add Akamai CDN auth to the Che builds

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1724,6 +1724,7 @@
             - *che-bot-github-credentials
             - *eclipse-che-oss-sonatype
             - *eclipse-che-github-ssh-key
+            - *che-akamai-cdn-auth            
     scm:
         - git:
             url: https://github.com/{git_organization}/{git_repo}.git

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -461,6 +461,13 @@
       - env-var: 'GPG_PASSPHRASE'
         vault-key: 'gpg.passphrase'
 
+- che-akamai-cdn-auth: &che-akamai-cdn-auth
+    name: "che-akamai-cdn-auth"
+    secret-path: "devtools-osio-ci/akamai-che-auth"
+    secret-values:
+      - env-var: 'AKAMAI_CHE_AUTH'
+        vault-key: 'AKAMAI_CHE_AUTH'
+
 - wrapper:
     name: che_credentials_wrapper
     wrappers:
@@ -1612,6 +1619,7 @@
             - *quay-eclipse-che-credentials
             - *che-bot-github-credentials
             - *eclipse-che-oss-sonatype
+            - *che-akamai-cdn-auth
 
     <<: *job_template_build_master
 


### PR DESCRIPTION
This is needed for `che-theia` builds, in order to be able to push the CDN files to the Akamai NetStorage account.

Related issue about broken CDN support in che-theia after the migration of CI to centos-ci: https://github.com/eclipse/che/issues/15791 